### PR TITLE
Chore: Removes the TODO around the @Size field validator for blobs (#21)

### DIFF
--- a/generators/entity-server/templates/src/main/java/package/common/field_validators.ejs
+++ b/generators/entity-server/templates/src/main/java/package/common/field_validators.ejs
@@ -39,17 +39,6 @@ if (field.fieldValidate === true) {
     if (rules.includes('minlength') && rules.includes('maxlength')) {
         validators.push('@Size(min = ' + field.fieldValidateRulesMinlength + ', max = ' + field.fieldValidateRulesMaxlength + ')');
     }
-    // TODO: Micronaut Issue #21
-    // Not supported anymore because the server can't check the size of the blob before downloading it completely.
-    // if (rules.includes('minbytes') && !rules.includes('maxbytes')) {
-    //     validators.push('@Size(min = ' + field.fieldValidateRulesMinbytes + ')');
-    // }
-    // if (rules.includes('maxbytes') && !rules.includes('minbytes')) {
-    //     validators.push('@Size(max = ' + field.fieldValidateRulesMaxbytes + ')');
-    // }
-    // if (rules.includes('minbytes') && rules.includes('maxbytes')) {
-    //     validators.push('@Size(min = ' + field.fieldValidateRulesMinbytes + ', max = ' + field.fieldValidateRulesMaxbytes + ')');
-    // }
     if (rules.includes('min')) {
         if (field.fieldType === 'Float' || field.fieldType === 'Double' || field.fieldType === 'BigDecimal') {
             validators.push('@DecimalMin(value = "' + field.fieldValidateRulesMin + '")');


### PR DESCRIPTION
Closes #21 