### PR TITLE
add release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,15 @@
+template: |
+    # What's Changed
+    $CHANGES
+categories:
+  - title: 💎 Features & Enhancements
+    labels: 
+      - enhancement 💎
+      - Auth 🔐
+      - Database 💾
+  - title: 🐞 Bug Fixes
+    label: bug 🐞
+  - title: 📝 Documentation
+    label: documentation 📝
+  - title: 📦 Dependency updates
+    label: dependencies

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,16 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We have release drafter now also in the main generator and I think its very helpful (as blueprints have no release notes on the website yet, but also afterwards).