### PR TITLE
environment can be defined via system property

### DIFF
--- a/generators/server/templates/src/main/java/package/App.java.ejs
+++ b/generators/server/templates/src/main/java/package/App.java.ejs
@@ -47,6 +47,8 @@ public class <%= mainClass %> {
         List<String> environments;
         if (System.getenv("MICRONAUT_ENVIRONMENTS") != null) {
             environments = Arrays.asList(System.getenv("MICRONAUT_ENVIRONMENTS").split(","));
+        } else if (System.getProperty("micronaut.environments") != null) {
+            environments = Arrays.asList(System.getProperty("micronaut.environments").split(","));
         } else {
             environments = DefaultProfileUtil.getDefaultEnvironments();
         }


### PR DESCRIPTION
In case the the environments are defined via `-Dmicronaut.environments` the dev profile is not added anymore (like with the environment variable).

```
java -jar -Dmicronaut.environments=foo,bar
----------------------------------------------------------
	Application 'jhipster-sample-application' is running! Access URLs:
	Local: 		http://localhost:14786
	External: 	http://localhost:14786
	Profile(s): 	[foo, test]
----------------------------------------------------------
```

closes #86