### PR TITLE
provide caffeine cache implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ $ jhipster --blueprints micronaut
   * PostgreSQL
   * H2
 * Ehcache
+* Caffeine Cache
 * Maven or Gradle Build System
 * Angular or React Client
 * Protractor Tests

--- a/generators/constants.js
+++ b/generators/constants.js
@@ -39,5 +39,7 @@ module.exports = {
         mapstruct: '1.3.1.Final',
         mockito: '3.1.0',
         problem: '0.24.0',
+        caffeine: '2.8.4',
+        archunit: '0.14.1'
     },
 };

--- a/generators/constants.js
+++ b/generators/constants.js
@@ -40,6 +40,6 @@ module.exports = {
         mockito: '3.1.0',
         problem: '0.24.0',
         caffeine: '2.8.4',
-        archunit: '0.14.1'
+        archunit: '0.14.1',
     },
 };

--- a/generators/server/prompts.js
+++ b/generators/server/prompts.js
@@ -240,6 +240,10 @@ function askForServerSideOpts(meta) {
                     name: 'Yes, with the Ehcache implementation (local cache, for a single node)',
                 },
                 {
+                    value: 'caffeine',
+                    name: 'Yes, with the Caffeine implementation (local cache, for a single node)',
+                },
+                {
                     value: 'no',
                     name: 'No - Warning, when using an SQL database, this will disable the Hibernate 2nd level cache!',
                 },

--- a/generators/server/templates/gradle.properties.ejs
+++ b/generators/server/templates/gradle.properties.ejs
@@ -28,14 +28,14 @@ npm_version=<%= NPM_VERSION %>
 yarn_version=<%= YARN_VERSION %>
 
 # Dependency versions
-jhipster_dependencies_version=<%=versions.jhipsterDeps%>
+jhipster_dependencies_version=<%= JHIPSTER_DEPENDENCIES_VERSION %>
 micronaut_version=<%=versions.micronaut%>
 micronaut_data_version=<%=versions.micronautData%>
 # The hibernate version should match the one managed by Micronaut data
 # https://mvnrepository.com/artifact/io.micronaut.data/micronaut-data-hibernate-jpa/1.0.1
 hibernate_version=<%=versions.hibernate%>
 mapstruct_version=<%=versions.mapstruct%>
-archunit_junit5_version=0.13.1
+archunit_junit5_version=<%=versions.archunit%>
 logback_version=<%=versions.logback%>
 mockito_version=<%=versions.mockito%>
 jbcrypt_version=<%=versions.jbcrypt%>
@@ -48,7 +48,7 @@ log4j2_mock_version=0.0.2
 jackson_databind_nullable_version=<%= JACKSON_DATABIND_NULLABLE_VERSION %>
 <%_ } _%>
 <%_ if (cacheProvider === 'caffeine') { _%>
-caffeine_version=2.8.4
+caffeine_version=<%=versions.caffeine%>
 typesafe_config_version=1.4.0
 <%_ } _%>
 

--- a/generators/server/templates/gradle.properties.ejs
+++ b/generators/server/templates/gradle.properties.ejs
@@ -48,7 +48,7 @@ log4j2_mock_version=0.0.2
 jackson_databind_nullable_version=<%= JACKSON_DATABIND_NULLABLE_VERSION %>
 <%_ } _%>
 <%_ if (cacheProvider === 'caffeine') { _%>
-caffeine_version=2.8.1
+caffeine_version=2.8.4
 typesafe_config_version=1.4.0
 <%_ } _%>
 
@@ -61,17 +61,17 @@ jaxb_runtime_version=2.3.2
 
 # gradle plugin version
 jib_plugin_version=<%= JIB_VERSION %>
-git_properties_plugin_version=2.2.0
+git_properties_plugin_version=2.2.2
 <%_ if (!skipClient) { _%>
-gradle_node_plugin_version=2.2.1
+gradle_node_plugin_version=2.2.4
 <%_ } _%>
 apt_plugin_version=0.21
 <%_ if (databaseType === 'sql') { _%>
-liquibase_plugin_version=2.0.2
+liquibase_plugin_version=2.0.3
 <%_ } _%>
 sonarqube_plugin_version=2.8
 <%_ if (enableSwaggerCodegen) { _%>
-openapi_plugin_version=4.2.2
+openapi_plugin_version=4.3.1
 <%_ } _%>
 shadow_plugin_version=5.2.0
 

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -18,6 +18,15 @@ _%>
             <id>jcenter</id>
             <url>https://jcenter.bintray.com</url>
         </repository>
+        <%_ if (JHIPSTER_DEPENDENCIES_VERSION.endsWith('-SNAPSHOT')) { _%>
+        <repository>
+            <id>ossrh-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+        <%_ } _%>
     </repositories>
 
     <pluginRepositories>
@@ -57,7 +66,7 @@ _%>
         <profile.tls />
 
         <!-- Dependency versions -->
-        <jhipster-dependencies.version><%= versions.jhipsterDeps %></jhipster-dependencies.version>
+        <jhipster-dependencies.version><%= JHIPSTER_DEPENDENCIES_VERSION %></jhipster-dependencies.version>
         <micronaut.version><%= versions.micronaut %></micronaut.version>
         <micronaut-data.version><%= versions.micronautData %></micronaut-data.version>
         <hibernate.version><%= versions.hibernate %></hibernate.version>
@@ -74,7 +83,7 @@ _%>
         <problem.version><%= versions.problem %></problem.version>
 
 <%_ if (cacheProvider === 'caffeine') { _%>
-        <caffeine.version>2.8.4</caffeine.version>
+        <caffeine.version><%= versions.caffeine %></caffeine.version>
         <typesafe.version>1.4.0</typesafe.version>
 <%_ } _%>
         <!-- Plugin versions -->
@@ -96,7 +105,7 @@ _%>
 <%_ } _%>
         <git-commit-id-plugin.version>2.2.6</git-commit-id-plugin.version>
         <jacoco-maven-plugin.version>0.8.3</jacoco-maven-plugin.version>
-        <jib-maven-plugin.version>0.9.11</jib-maven-plugin.version>
+        <jib-maven-plugin.version><%= JIB_VERSION %></jib-maven-plugin.version>
         <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
         <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>
         <sonar-maven-plugin.version>3.7.0.1746</sonar-maven-plugin.version>
@@ -712,7 +721,7 @@ if (devDatabaseType === 'postgresql' || prodDatabaseType === 'postgresql') { _%>
                     <version>${jib-maven-plugin.version}</version>
                     <configuration>
                         <from>
-                            <image>adoptopenjdk/openjdk11:alpine-jre</image>
+                            <image><%= DOCKER_JAVA_JRE %></image>
                         </from>
                         <to>
                             <image><%= lowercaseBaseName %>:latest</image>
@@ -732,6 +741,15 @@ if (devDatabaseType === 'postgresql' || prodDatabaseType === 'postgresql') { _%>
                             </environment>
                             <useCurrentTimestamp>true</useCurrentTimestamp>
                         </container>
+                        <extraDirectories>
+                            <paths><%= MAIN_DIR %>jib</paths>
+                            <permissions>
+                                <permission>
+                                    <file>/entrypoint.sh</file>
+                                    <mode>755</mode>
+                                </permission>
+                            </permissions>
+                        </extraDirectories>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -739,7 +739,7 @@ if (devDatabaseType === 'postgresql' || prodDatabaseType === 'postgresql') { _%>
                                 <SPRING_OUTPUT_ANSI_ENABLED>ALWAYS</SPRING_OUTPUT_ANSI_ENABLED>
                                 <JHIPSTER_SLEEP>0</JHIPSTER_SLEEP>
                             </environment>
-                            <useCurrentTimestamp>true</useCurrentTimestamp>
+                            <creationTime>USE_CURRENT_TIMESTAMP</creationTime>
                         </container>
                         <extraDirectories>
                             <paths><%= MAIN_DIR %>jib</paths>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -73,6 +73,10 @@ _%>
         <mockito.version><%= versions.mockito %></mockito.version>
         <problem.version><%= versions.problem %></problem.version>
 
+<%_ if (cacheProvider === 'caffeine') { _%>
+        <caffeine.version>2.8.4</caffeine.version>
+        <typesafe.version>1.4.0</typesafe.version>
+<%_ } _%>
         <!-- Plugin versions -->
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -236,6 +240,29 @@ if (devDatabaseType === 'postgresql' || prodDatabaseType === 'postgresql') { _%>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-jcache</artifactId>
             <version>${hibernate.version}</version>
+        </dependency>
+    <%_ } _%>
+<%_ } _%>
+<%_ if (cacheProvider === 'caffeine') { _%>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>${caffeine.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>jcache</artifactId>
+            <version>${caffeine.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe</groupId>
+            <artifactId>config</artifactId>
+            <version>${typesafe.version}</version>
+        </dependency>
+    <%_ if (enableHibernateCache) { _%>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-jcache</artifactId>
         </dependency>
     <%_ } _%>
 <%_ } _%>

--- a/generators/server/templates/src/main/java/package/config/CacheConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/CacheConfiguration.java.ejs
@@ -8,10 +8,27 @@ import java.util.Properties;
 import <%=packageName%>.util.JHipsterProperties;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.Factory;
+
+<%_ if (cacheProvider === 'ehcache') { _%>
 import org.ehcache.config.builders.*;
 import org.ehcache.jsr107.Eh107Configuration;
-
 import org.ehcache.jsr107.EhcacheCachingProvider;
+
+    <%_ if (enableHibernateCache) { _%>
+import org.hibernate.cache.jcache.ConfigSettings;
+    <%_ } _%>
+<%_ } _%>  
+
+<%_ if (cacheProvider === 'caffeine') { _%>
+import com.github.benmanes.caffeine.jcache.spi.CaffeineCachingProvider;
+import com.github.benmanes.caffeine.jcache.configuration.CaffeineConfiguration;
+import java.util.OptionalLong;
+import java.util.concurrent.TimeUnit;
+    
+    <%_ if (enableHibernateCache) { _%>
+import org.hibernate.cache.jcache.ConfigSettings;
+    <%_ } _%>
+<%_ } _%>
 
 import javax.cache.CacheManager;
 import javax.inject.Singleton;
@@ -22,7 +39,7 @@ public class CacheConfiguration {
     private final javax.cache.configuration.Configuration<Object, Object> jcacheConfiguration;
 
     public CacheConfiguration(JHipsterProperties jHipsterProperties) {
-       <%_ if (cacheProvider === 'ehcache') { _%>
+        <%_ if (cacheProvider === 'ehcache') { _%>
         JHipsterProperties.Cache.Ehcache ehcache =
             jHipsterProperties.getCache().getEhcache();
 
@@ -31,15 +48,26 @@ public class CacheConfiguration {
                 ResourcePoolsBuilder.heap(ehcache.getMaxEntries()))
                 .withExpiry(ExpiryPolicyBuilder.timeToLiveExpiration(Duration.ofSeconds(ehcache.getTimeToLiveSeconds())))
                 .build());
+        <%_ } else { _%>
+        JHipsterProperties.Cache.Caffeine caffeine = jHipsterProperties.getCache().getCaffeine();
+            
+        CaffeineConfiguration<Object, Object> caffeineConfiguration = new CaffeineConfiguration<>();
+        caffeineConfiguration.setMaximumSize(OptionalLong.of(caffeine.getMaxEntries()));
+        caffeineConfiguration.setExpireAfterWrite(OptionalLong.of(TimeUnit.SECONDS.toNanos(caffeine.getTimeToLiveSeconds())));
+        caffeineConfiguration.setStatisticsEnabled(true);
+        jcacheConfiguration = caffeineConfiguration;
         <%_ } _%>
-
-        // TODO add caffiene configuration
     }
 
     @Singleton
     public CacheManager cacheManager(ApplicationContext applicationContext) {
+        <%_ if (cacheProvider === 'ehcache') { _%>
         CacheManager cacheManager = new EhcacheCachingProvider().getCacheManager(
             null, applicationContext.getClassLoader(), new Properties());
+        <%_ } else { _%>
+        CacheManager cacheManager = new CaffeineCachingProvider().getCacheManager(
+                null, applicationContext.getClassLoader(), new Properties());
+        <%_ } _%>
         customizeCacheManager(cacheManager);
         return cacheManager;
     }
@@ -60,7 +88,6 @@ public class CacheConfiguration {
         // jhipster-needle-ehcache-add-entry
         <%_ } _%>
         <%_ if (cacheProvider === 'caffeine') { _%>
-        // TODO not yet implemented
         // jhipster-needle-caffeine-add-entry
         <%_ } _%>
     }

--- a/generators/server/templates/src/main/java/package/util/JHipsterProperties.java.ejs
+++ b/generators/server/templates/src/main/java/package/util/JHipsterProperties.java.ejs
@@ -161,12 +161,17 @@ public class JHipsterProperties {
     public static class Cache {
 
         private final Hazelcast hazelcast = new Hazelcast();
+        private final Caffeine caffeine = new Caffeine();
         private final Ehcache ehcache = new Ehcache();
         private final Infinispan infinispan = new Infinispan();
         private final Memcached memcached = new Memcached();
 
         public Hazelcast getHazelcast() {
             return hazelcast;
+        }
+
+        public Caffeine getCaffeine() {
+            return caffeine;
         }
 
         public Ehcache getEhcache() {
@@ -335,6 +340,29 @@ public class JHipsterProperties {
                 public void setMaxEntries(long maxEntries) {
                     this.maxEntries = maxEntries;
                 }
+            }
+        }
+
+        @ConfigurationProperties("caffeine")
+        public static class Caffeine {
+
+            private int timeToLiveSeconds = 3600;
+            private long maxEntries = 100;
+
+            public int getTimeToLiveSeconds() {
+                return timeToLiveSeconds;
+            }
+
+            public void setTimeToLiveSeconds(int timeToLiveSeconds) {
+                this.timeToLiveSeconds = timeToLiveSeconds;
+            }
+
+            public long getMaxEntries() {
+                return maxEntries;
+            }
+
+            public void setMaxEntries(long maxEntries) {
+                this.maxEntries = maxEntries;
             }
         }
 


### PR DESCRIPTION
This add caffeine support to generated application.

This also aligns the jhipster dependencies version with the main generator and uses the jib version defined in the main generator.

closes #46