### PR TITLE
Use jsr330 componentModel in EntityMapper

### DIFF
--- a/generators/entity-server/templates/src/main/java/package/service/mapper/EntityMapper.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/mapper/EntityMapper.java.ejs
@@ -57,7 +57,7 @@ import java.util.UUID;
 /**
  * Mapper for the entity {@link <%= asEntity(entityClass) %>} and its DTO {@link <%= asDto(entityClass) %>}.
  */
-@Mapper(componentModel = "spring", uses = {<%= existingMappings.map(otherEntityNameCapitalized => otherEntityNameCapitalized + 'Mapper.class').join(', ') %>})
+@Mapper(componentModel = "jsr330", uses = {<%= existingMappings.map(otherEntityNameCapitalized => otherEntityNameCapitalized + 'Mapper.class').join(', ') %>})
 public interface <%= entityClass %>Mapper extends EntityMapper<<%= asDto(entityClass) %>, <%= asEntity(entityClass) %>> {
 
 <%_


### PR DESCRIPTION
MapStruct allows generating jsr330 beans, which is what micronaut is using.

![image](https://user-images.githubusercontent.com/2544251/84596407-8250ad80-ae55-11ea-8301-bf21744c8f58.png)

https://mapstruct.org/documentation/dev/reference/pdf/mapstruct-reference-guide.pdf

Method annotated with `componentMapping="spring"` causes strange initialisation-runtime error as spring stereotype component isn't in classpath, but it's referenced from code in target/. Error is not visible in intellij or maven as mappers are not part of the codebase.