### PR TITLE
add security headers

### DIFF
--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -117,6 +117,10 @@ module.exports = class extends HerokuGeneratorOverride {
                     'SSLEnforcingHostResolver.java.ejs',
                     `${constants.SERVER_MAIN_SRC_DIR}${this.packageFolder}/config/SSLEnforcingHostResolver.java`
                 );
+                this.template(
+                    'StrictTransportSecurityHeaderFilter.java.ejs',
+                    `${constants.SERVER_MAIN_SRC_DIR}${this.packageFolder}/security/StrictTransportSecurityHeaderFilter.java`
+                );
                 if (this.buildTool === 'gradle') {
                     this.template('heroku.gradle.ejs', 'gradle/heroku.gradle');
                 }

--- a/generators/heroku/templates/StrictTransportSecurityHeaderFilter.java.ejs
+++ b/generators/heroku/templates/StrictTransportSecurityHeaderFilter.java.ejs
@@ -1,0 +1,29 @@
+package <%=packageName%>.security;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.async.publisher.Publishers;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.annotation.Filter;
+import io.micronaut.http.filter.OncePerRequestHttpServerFilter;
+import io.micronaut.http.filter.ServerFilterChain;
+import org.reactivestreams.Publisher;
+
+import static io.micronaut.http.annotation.Filter.MATCH_ALL_PATTERN;
+
+@Filter(patterns = {MATCH_ALL_PATTERN})
+@Requires(env = Environment.HEROKU)
+public class StrictTransportSecurityHeaderFilter extends OncePerRequestHttpServerFilter {
+
+    private static final String STRICT_TRANSPORT_SECURITY_HEADER = "Strict-Transport-Security";
+
+    @Override
+    protected Publisher<MutableHttpResponse<?>> doFilterOnce(HttpRequest<?> request, ServerFilterChain chain) {
+
+        return Publishers.map(chain.proceed(request), mutableHttpResponse -> {
+            mutableHttpResponse.header(STRICT_TRANSPORT_SECURITY_HEADER, "max-age=31536000; includeSubDomains");
+            return mutableHttpResponse;
+        });
+    }
+}

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -458,6 +458,11 @@ const serverFiles = {
                     renameTo: generator => `${generator.javaDir}security/UserNotActivatedException.java`,
                     useBluePrint: true,
                 },
+                {
+                    file: 'package/security/SecurityHeaderFilter.java',
+                    renameTo: generator => `${generator.javaDir}security/SecurityHeaderFilter.java`,
+                    useBluePrint: true,
+                },
             ],
         },
         {
@@ -749,6 +754,11 @@ const serverFiles = {
                 {
                     file: 'package/security/jwt/JWTFilterTest.java',
                     renameTo: generator => `${generator.javaDir}security/jwt/JWTFilterTest.java`,
+                    useBluePrint: true,
+                },
+                {
+                    file: 'package/security/SecurityHeaderFilterTest.java',
+                    renameTo: generator => `${generator.javaDir}security/SecurityHeaderFilterTest.java`,
                     useBluePrint: true,
                 },
             ],

--- a/generators/server/templates/src/main/java/package/security/SecurityHeaderFilter.java.ejs
+++ b/generators/server/templates/src/main/java/package/security/SecurityHeaderFilter.java.ejs
@@ -1,0 +1,44 @@
+package <%=packageName%>.security;
+
+import io.micronaut.core.async.publisher.Publishers;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.annotation.Filter;
+import io.micronaut.http.filter.OncePerRequestHttpServerFilter;
+import io.micronaut.http.filter.ServerFilterChain;
+import org.reactivestreams.Publisher;
+
+import static io.micronaut.http.annotation.Filter.MATCH_ALL_PATTERN;
+
+@Filter(patterns = {MATCH_ALL_PATTERN})
+public class SecurityHeaderFilter extends OncePerRequestHttpServerFilter {
+
+    private static final String X_FRAME_OPTIONS_HEADER = "X-Frame-Options";
+    private static final String X_CONTENT_TYPE_OPTIONS_HEADER = "X-Content-Type-Options";
+    private static final String X_XSS_PROTECTION_HEADER = "X-XSS-Protection";
+    private static final String REFERRER_POLICY_HEADER = "Referrer-Policy";
+    private static final String FEATURE_POLICY_HEADER = "Feature-Policy";
+    private static final String CONTENT_SECURITY_POLICY_HEADER = "Content-Security-Policy";
+
+    @Override
+    protected Publisher<MutableHttpResponse<?>> doFilterOnce(HttpRequest<?> request, ServerFilterChain chain) {
+
+        return Publishers.map(chain.proceed(request), mutableHttpResponse -> {
+            addSecurityHeaders(mutableHttpResponse);
+            return mutableHttpResponse;
+        });
+    }
+
+    protected void addSecurityHeaders(MutableHttpResponse<?> response) {
+        response.header(X_FRAME_OPTIONS_HEADER, "DENY");
+        response.header(X_CONTENT_TYPE_OPTIONS_HEADER, "nosniff");
+        response.header(X_XSS_PROTECTION_HEADER, "1; mode=block");
+        response.header(REFERRER_POLICY_HEADER, "strict-origin-when-cross-origin");
+        response.header(FEATURE_POLICY_HEADER, "geolocation 'none'; midi 'none'; sync-xhr 'none'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; speaker 'none'; fullscreen 'self'; payment 'none'");
+        <%_ if (clientTheme !== 'none') { _%>
+        response.header(CONTENT_SECURITY_POLICY_HEADER, "default-src 'self'; frame-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://storage.googleapis.com; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com data:");
+        <%_ } else { _%>
+        response.header(CONTENT_SECURITY_POLICY_HEADER, "default-src 'self'; frame-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://storage.googleapis.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:");
+        <%_ } _%>
+    }
+}

--- a/generators/server/templates/src/test/java/package/security/SecurityHeaderFilterTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/security/SecurityHeaderFilterTest.java.ejs
@@ -1,0 +1,30 @@
+package <%=packageName%>.security;
+
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.simple.SimpleHttpResponseFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+class SecurityHeaderFilterTest {
+
+    private final SecurityHeaderFilter subject = new SecurityHeaderFilter();
+
+    @Test
+    public void assertSecurityHeadersAreAdded() {
+
+        MutableHttpResponse<Object> response = new SimpleHttpResponseFactory().ok();
+        subject.addSecurityHeaders(response);
+
+        assertThat(response.header("X-Frame-Options")).isEqualTo("DENY");
+        assertThat(response.header("X-Content-Type-Options")).isEqualTo("nosniff");
+        assertThat(response.header("X-XSS-Protection")).isEqualTo("1; mode=block");
+        assertThat(response.header("Referrer-Policy")).isEqualTo("strict-origin-when-cross-origin");
+        assertThat(response.header("Feature-Policy")).isEqualTo("geolocation 'none'; midi 'none'; sync-xhr 'none'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; speaker 'none'; fullscreen 'self'; payment 'none'");
+        <%_ if (clientTheme !== 'none') { _%>
+        assertThat(response.header("Content-Security-Policy")).isEqualTo("default-src 'self'; frame-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://storage.googleapis.com; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com data:");
+        <%_ } else { _%>
+        assertThat(response.header("Content-Security-Policy")).isEqualTo("default-src 'self'; frame-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://storage.googleapis.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:");
+        <%_ } _%>
+    }
+}


### PR DESCRIPTION
Adds the same security headers as we have for spring boot. The Strict-Transport-Security is only added for heroku right now as we can't make sure ssl is used e.g. in prod profile (of course it should)

![image](https://user-images.githubusercontent.com/203401/88087688-96d94180-cb89-11ea-81aa-6876aca67e01.png)


close #124

CC @mraible guess you like this :tada: 