### PR TITLE
Fix heroku deployement for app names starting with "p" or later

### DIFF
--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -1,5 +1,6 @@
 /* eslint-disable consistent-return,max-classes-per-file */
 const chalk = require('chalk');
+const _ = require('lodash');
 const fs = require('fs');
 const ChildProcess = require('child_process');
 const util = require('util');
@@ -69,6 +70,7 @@ module.exports = class extends HerokuGeneratorOverride {
                 const configuration = this.getAllJhipsterConfig(this, true);
                 this.env.options.appPath = configuration.get('appPath') || constants.CLIENT_MAIN_SRC_DIR;
                 this.baseName = configuration.get('baseName');
+                this.dasherizedBaseName = _.kebabCase(this.baseName);
                 this.packageName = configuration.get('packageName');
                 this.packageFolder = configuration.get('packageFolder');
                 this.cacheProvider = configuration.get('cacheProvider') || configuration.get('hibernateCache') || 'no';

--- a/generators/heroku/templates/Procfile.ejs
+++ b/generators/heroku/templates/Procfile.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-web: java $JAVA_OPTS <% if (applicationType === 'gateway' || dynoSize === 'Free') { %>-Xmx128m<% } %> -Dmicronaut.env.deduction=false -Dmicronaut.environments=prod,cloud<% if (buildTool == 'maven' && herokuDeployType == 'git') { %>,no-liquibase<% } %>,heroku -Dmicronaut.server.port=$port -jar <% if (buildTool === 'maven') { %>target/*.jar<% } %><% if (buildTool === 'gradle') { %>build/libs/*-all.jar<% } %>
+web: java $JAVA_OPTS <% if (applicationType === 'gateway' || dynoSize === 'Free') { %>-Xmx128m<% } %> -Dmicronaut.env.deduction=false -Dmicronaut.environments=prod,cloud<% if (buildTool == 'maven' && herokuDeployType == 'git') { %>,no-liquibase<% } %>,heroku -Dmicronaut.server.port=$port -jar <% if (buildTool === 'maven') { %>target/<%= dasherizedBaseName %>*.jar<% } %><% if (buildTool === 'gradle') { %>build/libs/*-all.jar<% } %>
 <%_ if (buildTool == 'maven' && herokuDeployType == 'git' && (prodDatabaseType === 'postgresql' || prodDatabaseType === 'mysql' || prodDatabaseType === 'mariadb')) { _%>
 release: cp -R src/main/resources/config config && ./mvnw -ntp liquibase:update -Pprod,heroku
 <%_ } _%>


### PR DESCRIPTION
When building a jar with maven we have two jars:

* xyz.jar (which is the exeutable jar) and
* original-xyz.jar

The procfile just started `*.jar` in case the app name was before `o` everything worked fine. In case the original jar was lexicographical before the executable jar it was tried to start that. In the main generator we don't have that problem as the original jar is named xyz.jar.original so we could just reference `*.jar`.

closes #126