### PR TITLE
Executing just `./mvnw` compiles the frontend

### DIFF
--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -490,7 +490,7 @@ if (devDatabaseType === 'postgresql' || prodDatabaseType === 'postgresql') { _%>
         <!-- jhipster-needle-maven-add-dependency -->
     </dependencies>
     <build>
-        <defaultGoal>mn:run</defaultGoal>
+        <defaultGoal>package mn:run</defaultGoal>
       
         <plugins>
             <plugin>


### PR DESCRIPTION
This makes `./mvnw` also compile the frontend (and doing java tests). Editing a java class makes the micronaut plugin just compiling the class and changes are available directly in the current running application.