### PR TITLE
Do not create fake data when deploying to heroku

### DIFF
--- a/generators/heroku/templates/Procfile.ejs
+++ b/generators/heroku/templates/Procfile.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-web: java $JAVA_OPTS <% if (applicationType === 'gateway' || dynoSize === 'Free') { %>-Xmx128m<% } %> -Dmicronaut.env.deduction=false -Dmicronaut.environments=prod,cloud<% if (buildTool == 'maven' && herokuDeployType == 'git') { %>,no-liquibase<% } %>,heroku -Dmicronaut.server.port=$port -jar <% if (buildTool === 'maven') { %>target/<%= dasherizedBaseName %>*.jar<% } %><% if (buildTool === 'gradle') { %>build/libs/*-all.jar<% } %>
+web: java $JAVA_OPTS <% if (applicationType === 'gateway' || dynoSize === 'Free') { %>-Xmx128m<% } %> -Dmicronaut.env.deduction=false -Dmicronaut.environments=prod,cloud<% if (buildTool == 'maven' && herokuDeployType == 'git') { %>,no-liquibase<% } %>,heroku -jar <% if (buildTool === 'maven') { %>target/<%= dasherizedBaseName %>*.jar<% } %><% if (buildTool === 'gradle') { %>build/libs/*-all.jar<% } %>
 <%_ if (buildTool == 'maven' && herokuDeployType == 'git' && (prodDatabaseType === 'postgresql' || prodDatabaseType === 'mysql' || prodDatabaseType === 'mariadb')) { _%>
 release: cp -R src/main/resources/config config && ./mvnw -ntp liquibase:update -Pprod,heroku
 <%_ } _%>

--- a/generators/heroku/templates/application-heroku.yml.ejs
+++ b/generators/heroku/templates/application-heroku.yml.ejs
@@ -30,6 +30,8 @@
 
 
 micronaut:
+  server:
+    port: ${PORT:8080}
   security:
     token:
       jwt:

--- a/generators/heroku/templates/application-heroku.yml.ejs
+++ b/generators/heroku/templates/application-heroku.yml.ejs
@@ -74,3 +74,8 @@ datasources:
       maximum-pool-size: 8
 <%_ } _%>
 
+liquibase:
+  datasources:
+    default:
+      contexts: prod
+

--- a/generators/heroku/templates/pom-profile.xml.ejs
+++ b/generators/heroku/templates/pom-profile.xml.ejs
@@ -15,6 +15,7 @@
                             <verbose>true</verbose>
                             <logging>debug</logging>
                             <promptOnNonLocalDatabase>false</promptOnNonLocalDatabase>
+                            <contexts>prod</contexts>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
This sets the liquibase context when deploying to heroku in 

* properties (e.g. when using docker, gradle)
* in pom profile which is uses in the procfile