### PR TITLE
do not load faker data in prod environment

### DIFF
--- a/generators/server/templates/src/main/resources/application-prod.yml.ejs
+++ b/generators/server/templates/src/main/resources/application-prod.yml.ejs
@@ -91,7 +91,7 @@ liquibase:
     default:
       async: true
       change-log: classpath:config/liquibase/master.xml
-      contexts: prod,faker
+      contexts: prod
 mail:
   host: localhost
   port: 25


### PR DESCRIPTION
Somehow we missed this in `prod` properties

updates #168