### PR TITLE
create h2 db files in gradle build dir, support h2 console-ui

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.html.ejs
@@ -121,7 +121,7 @@
                     <!-- jhipster-needle-add-element-to-admin-menu - JHipster will add entities to the admin menu here -->
                     <%_ if (devDatabaseType === 'h2Disk' || devDatabaseType === 'h2Memory' || devDatabaseType === 'couchbase') { _%>
                     <li *ngIf="!inProduction">
-                        <a class="dropdown-item" href='<% if (devDatabaseType === 'couchbase') { %>http://localhost:8091/<% } else { %>./h2-console<% } %>' target="_tab" (click)="collapseNavbar()">
+                        <a class="dropdown-item" href='<% if (devDatabaseType === 'couchbase') { %>http://localhost:8091/<% } else { %>http://localhost:8082<% } %>' target="_tab" (click)="collapseNavbar()">
                             <fa-icon icon="hdd" [fixedWidth]="true"></fa-icon>
                             <span jhiTranslate="global.menu.admin.database">Database</span>
                         </a>

--- a/generators/server/templates/src/main/java/package/App.java.ejs
+++ b/generators/server/templates/src/main/java/package/App.java.ejs
@@ -13,6 +13,9 @@ import io.micronaut.runtime.server.EmbeddedServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+<%_ if (devDatabaseType === 'h2Memory' || devDatabaseType === 'h2Disk') { _%>
+import java.lang.reflect.Method;
+<%_ } _%>
 import java.util.*;
 
 public class <%= mainClass %> {
@@ -61,6 +64,13 @@ public class <%= mainClass %> {
         checkProfiles(context.getEnvironment());
 
         logApplicationStartup(context);
+
+        <%_ if (devDatabaseType === 'h2Memory' || devDatabaseType === 'h2Disk') { _%>
+        if (environments.contains(JHipsterConstants.SPRING_PROFILE_DEVELOPMENT)) {
+            startH2WebConsole();
+        }
+        <%_ } _%>
+
     }
 
     private static void logApplicationStartup(ApplicationContext context) {
@@ -84,4 +94,20 @@ public class <%= mainClass %> {
             serverPort,
             context.getEnvironment().getActiveNames());
     }
+
+    <%_ if (devDatabaseType === 'h2Memory' || devDatabaseType === 'h2Disk') { _%>
+    private static void startH2WebConsole() {
+        try {
+            ClassLoader loader = Thread.currentThread().getContextClassLoader();
+            Class<?> serverClass = Class.forName("org.h2.tools.Server", true, loader);
+            Method createWebServer = serverClass.getMethod("createWebServer", String[].class);
+            Method start = serverClass.getMethod("start");
+
+            Object server = createWebServer.invoke(null, new Object[]{new String[]{"-properties", "src/main/resources/"}});
+            start.invoke(server);
+        } catch (Exception  e) {
+            log.trace("Unable to start H2 console.", e);
+        }
+    }
+    <%_ } _%>
 }

--- a/generators/server/templates/src/main/resources/application-dev.yml.ejs
+++ b/generators/server/templates/src/main/resources/application-dev.yml.ejs
@@ -34,8 +34,11 @@ _%>
   if (devDatabaseType === 'h2Disk' || devDatabaseType === 'h2Memory') {
     dbUser = baseName;
     dbUrlConfig.databaseName = lowercaseBaseName;
-    if (devDatabaseType === 'h2Disk') {
-      dbUrlConfig.localDirectory = `${BUILD_DIR}/h2db/db`;
+    if (devDatabaseType === 'h2Disk' && buildTool === 'gradle') {
+      dbUrlConfig.localDirectory = `./${BUILD_DIR}/h2db/db`;
+    }
+    if (devDatabaseType === 'h2Disk' && buildTool === 'maven') {
+      dbUrlConfig.localDirectory = `./h2db/db`;
     }
   }
 

--- a/generators/server/templates/src/main/resources/application-dev.yml.ejs
+++ b/generators/server/templates/src/main/resources/application-dev.yml.ejs
@@ -35,7 +35,7 @@ _%>
     dbUser = baseName;
     dbUrlConfig.databaseName = lowercaseBaseName;
     if (devDatabaseType === 'h2Disk') {
-      dbUrlConfig.localDirectory = './h2db/db';
+      dbUrlConfig.localDirectory = `${BUILD_DIR}/h2db/db`;
     }
   }
 

--- a/generators/server/templates/src/main/resources/h2.server.properties.ejs
+++ b/generators/server/templates/src/main/resources/h2.server.properties.ejs
@@ -1,5 +1,10 @@
 #H2 Server Properties
+<%_ if (devDatabaseType === 'h2Memory') { _%>
 0=JHipster H2 (Memory)|org.h2.Driver|jdbc\:h2\:mem\:<%= lowercaseBaseName %>|<%= baseName %>
+<%_ } _%>
+<%_ if (devDatabaseType === 'h2Disk') { _%>
+0=JHipster H2 (Disk)|org.h2.Driver|jdbc\:h2\:file\:./<%= BUILD_DIR %>h2db/db/<%= lowercaseBaseName %>|<%= baseName %>
+<%_ } _%>
 webAllowOthers=true
 webPort=8082
 webSSL=false


### PR DESCRIPTION
While checking #168 I noticed the h2 db files are not under `/target`/`build`. I can't see any specific reason why we should not put them under the build output directory.