### PR TITLE
Add support for entity filtering, using micronaut-data-spring-jpa support for JpaSpecificationExecutor

### DIFF
--- a/generators/app/__snapshots__/generator.spec.mjs.snap
+++ b/generators/app/__snapshots__/generator.spec.mjs.snap
@@ -164,6 +164,12 @@ Object {
   "src/main/java/com/mycompany/myapp/repository/AuthorityRepository.java": Object {
     "stateCleared": "modified",
   },
+  "src/main/java/com/mycompany/myapp/repository/MHipsterJpaSpecificationExecutor.java": Object {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/repository/SpringDataTypeConverters.java": Object {
+    "stateCleared": "modified",
+  },
   "src/main/java/com/mycompany/myapp/repository/UserRepository.java": Object {
     "stateCleared": "modified",
   },

--- a/generators/entity-server/files.cjs
+++ b/generators/entity-server/files.cjs
@@ -117,8 +117,7 @@ const serverFiles = {
       path: SERVER_MAIN_SRC_DIR,
       templates: [
         {
-          file: 'package/service/dto/EntityCriteria.java',
-          useBluePrint: true,
+          file: 'package/service/criteria/EntityCriteria.java',
           renameTo: generator => `${generator.packageFolder}/service/dto/${generator.entityClass}Criteria.java`,
         },
         {

--- a/generators/entity-server/templates/src/main/java/package/common/get_all_template.ejs
+++ b/generators/entity-server/templates/src/main/java/package/common/get_all_template.ejs
@@ -24,7 +24,7 @@
     const entityToDtoReference = mapper + '::'+ 'toDto';
 _%>
 <%_ if (jpaMetamodelFiltering) { _%>
-    public HttpResponse<List<<%= instanceType %>>> getAll<%= entityClassPlural %>(<%= entityClass %>Criteria criteria<% if (pagination != 'no') { %>, Pageable pageable<% if (reactive) { %>, HttpRequest request<% } %><% } %>) {
+    public HttpResponse<List<<%= instanceType %>>> getAll<%= entityClassPlural %>(HttpRequest<?> request, <%= entityClass %>Criteria criteria<% if (pagination != 'no') { %>, Pageable pageable<% if (reactive) { %>, HttpRequest request<% } %><% } %>) {
         log.debug("REST request to get <%= entityClassPlural %> by criteria: {}", criteria);
     <%_ if (pagination === 'no') { _%>
         List<<%= instanceType %>> entityList = <%= entityInstance %>QueryService.findByCriteria(criteria);
@@ -42,7 +42,7 @@ _%>
      * @param criteria the criteria which the requested entities should match.
      * @return the {@link HttpResponse} with status {@code 200 (OK)} and the count in body.
      */
-    @Get("/<%= entityApiUrl %>/count")
+    @Get("/<%= entityApiUrl %>/count{?criteria*}")
     public HttpResponse<Long> count<%= entityClassPlural %>(<%= entityClass %>Criteria criteria) {
         log.debug("REST request to count <%= entityClassPlural %> by criteria: {}", criteria);
         return HttpResponse.ok().body(<%= entityInstance %>QueryService.countByCriteria(criteria));

--- a/generators/entity-server/templates/src/main/java/package/repository/EntityRepository.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/EntityRepository.java.ejs
@@ -30,6 +30,9 @@ import io.micronaut.data.annotation.Query;
 import io.micronaut.data.annotation.Repository;
 import io.micronaut.data.jpa.repository.JpaRepository;
 
+<%_ if (jpaMetamodelFiltering) { _%>
+import <%= packageName %>.repository.MHipsterJpaSpecificationExecutor;
+<%_ } _%>
 
     <%_ if (fieldsContainOwnerManyToMany) { _%>
 // TODO what is MN equivalent?
@@ -80,7 +83,7 @@ import java.util.UUID;
 @SuppressWarnings("unused")
 <%_ } _%>
 @Repository
-public interface <%= entityClass %>Repository extends <% if (databaseType === 'sql') { %>JpaRepository<% } %><% if (databaseType === 'mongodb') { %>MongoRepository<% } %><% if (databaseType === 'cassandra') { %>CassandraRepository<% } %><% if (databaseType === 'couchbase') { %>N1qlCouchbaseRepository<% } %><<%= asEntity(entityClass) %>, <%= primaryKey.type %>><% if (jpaMetamodelFiltering) { %>, JpaSpecificationExecutor<<%= asEntity(entityClass) %>><% } %> {
+public interface <%= entityClass %>Repository extends <% if (databaseType === 'sql') { %>JpaRepository<% } %><% if (databaseType === 'mongodb') { %>MongoRepository<% } %><% if (databaseType === 'cassandra') { %>CassandraRepository<% } %><% if (databaseType === 'couchbase') { %>N1qlCouchbaseRepository<% } %><<%= asEntity(entityClass) %>, <%= primaryKey.type %>><% if (jpaMetamodelFiltering) { %>, MHipsterJpaSpecificationExecutor<<%= asEntity(entityClass) %>><% } %> {
 
     <%_ for (idx in relationships) {
         if (relationships[idx].relationshipType === 'many-to-one' && relationships[idx].otherEntityName === 'user' && databaseType === 'sql') { _%>

--- a/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
@@ -104,8 +104,8 @@ import org.springframework.http.HttpStatus; %>
 <%# import org.springframework.http.MediaType; %>
 <%_ } _%>
 <%# import org.springframework.http.HttpResponse; %>
-<%_ if (!viaService && !saveUserSnapshot) { _%>
-<%# import org.springframework.transaction.annotation.Transactional; %>
+<%_ if (databaseType === 'sql' && !viaService && !saveUserSnapshot) { _%>
+import org.springframework.transaction.annotation.Transactional;
 <%_ } _%>
 
 <%_ if (reactive) { _%>
@@ -135,6 +135,9 @@ import static org.elasticsearch.index.query.QueryBuilders.*;
 /**
  * REST controller for managing {@link <%= packageName %>.domain.<%= asEntity(entityClass) %>}.
  */
+<%_ if (databaseType === 'sql' && !viaService && !saveUserSnapshot) { _%>
+@Transactional
+<%_ } _%>
 @Controller("/api")
 public class <%= entityClass %>Resource {
 

--- a/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
@@ -255,7 +255,7 @@ public class <%= entityClass %>Resource {
      <%_ } _%>
      * @return the {@link HttpResponse} with status {@code 200 (OK)} and the list of <%= entityInstancePlural %> in body.
      */
-    @Get("/<%= entityApiUrl %><% if (!jpaMetamodelFiltering && fieldsContainOwnerManyToMany) { _%>{?eagerload}<% } %>")
+    @Get("/<%= entityApiUrl %><% if (jpaMetamodelFiltering) { _%>{?criteria*}<% } else if (fieldsContainOwnerManyToMany) { _%>{?eagerload}<% } %>")
     @ExecuteOn(TaskExecutors.IO)
     <%_ if (databaseType === 'sql' && isUsingMapsId === true && !viaService) { _%>
     @ReadOnly

--- a/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
@@ -550,7 +550,6 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') {
         // Get the <%= entityInstance %>List w/ all the <%= entityInstancePlural %>
         List<<%= httpEntityClass %>> <%= entityInstancePlural %> = client.retrieve(HttpRequest.GET("/api/<%= entityApiUrl %>?eagerload=true"), Argument.listOf(<%= httpEntityClass %>.class)).blockingFirst();
         <%= httpEntityClass %> test<%= entityClass %> = <%= entityInstancePlural %>.get(0);
-
 <%- include('../../common/validate_entity_fields_template', {isUpdate: false}); -%>
     }
 
@@ -564,7 +563,6 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') {
 
         // Get the <%= entityInstance %>
         <%= httpEntityClass %> test<%= entityClass %> = client.retrieve(HttpRequest.GET("/api/<%= entityApiUrl %>/" + <%= entityInstance %>.getId()), <%= httpEntityClass %>.class).blockingFirst();
-
 <%- include('../../common/validate_entity_fields_template', {isUpdate: false}); -%>
     }
 
@@ -674,6 +672,235 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') {
         // Validate the <%= entityClass %> in Elasticsearch
         verify(mock<%= entityClass %>SearchRepository, times(1)).deleteById(<%= asEntity(entityInstance) %>.getId());
         <%_ } _%>
+    }
+<%_ } _%>
+
+<%_ if (jpaMetamodelFiltering) {  %>
+
+    @Test
+    void get<%= entityClassPlural %>ByIdFiltering() {
+        // Initialize the database
+        <%= entityInstance %>Repository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(<%= asEntity(entityInstance) %>);
+
+        Long id = <%= asEntity(entityInstance) %>.getId();
+
+        default<%= entityClass %>ShouldBeFound("id.equals=" + id);
+        default<%= entityClass %>ShouldNotBeFound("id.notEquals=" + id);
+
+        default<%= entityClass %>ShouldBeFound("id.greaterThanOrEqual=" + id);
+        default<%= entityClass %>ShouldNotBeFound("id.greaterThan=" + id);
+
+        default<%= entityClass %>ShouldBeFound("id.lessThanOrEqual=" + id);
+        default<%= entityClass %>ShouldNotBeFound("id.lessThan=" + id);
+    }
+
+<%_
+        fields.forEach((searchBy) => {
+            // we can't filter by all the fields.
+            if (isFilterableType(searchBy.fieldType)) {
+                 _%>
+
+    @Test
+    void getAll<%= entityClassPlural %>By<%= searchBy.fieldInJavaBeanMethod %>IsEqualToSomething() {
+        // Initialize the database
+        <%= entityInstance %>Repository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(<%= asEntity(entityInstance) %>);
+
+        // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> equals to <%= 'DEFAULT_' + searchBy.fieldNameUnderscored.toUpperCase() %>
+        default<%= entityClass %>ShouldBeFound("<%= searchBy.fieldName %>.equals=" + <%= 'DEFAULT_' + searchBy.fieldNameUnderscored.toUpperCase() %>);
+
+        // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> equals to <%= 'UPDATED_' + searchBy.fieldNameUnderscored.toUpperCase() %>
+        default<%= entityClass %>ShouldNotBeFound("<%= searchBy.fieldName %>.equals=" + <%= 'UPDATED_' + searchBy.fieldNameUnderscored.toUpperCase() %>);
+    }
+
+    @Test
+    void getAll<%= entityClassPlural %>By<%= searchBy.fieldInJavaBeanMethod %>IsNotEqualToSomething() {
+        // Initialize the database
+        <%= entityInstance %>Repository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(<%= asEntity(entityInstance) %>);
+
+        // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> not equals to <%= 'DEFAULT_' + searchBy.fieldNameUnderscored.toUpperCase() %>
+        default<%= entityClass %>ShouldNotBeFound("<%= searchBy.fieldName %>.notEquals=" + <%= 'DEFAULT_' + searchBy.fieldNameUnderscored.toUpperCase() %>);
+
+        // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> not equals to <%= 'UPDATED_' + searchBy.fieldNameUnderscored.toUpperCase() %>
+        default<%= entityClass %>ShouldBeFound("<%= searchBy.fieldName %>.notEquals=" + <%= 'UPDATED_' + searchBy.fieldNameUnderscored.toUpperCase() %>);
+    }
+
+    @Test
+    void getAll<%= entityClassPlural %>By<%= searchBy.fieldInJavaBeanMethod %>IsInShouldWork() {
+        // Initialize the database
+        <%= entityInstance %>Repository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(<%= asEntity(entityInstance) %>);
+
+        // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> in <%= 'DEFAULT_' + searchBy.fieldNameUnderscored.toUpperCase() %> or <%= 'UPDATED_' + searchBy.fieldNameUnderscored.toUpperCase() %>
+        default<%= entityClass %>ShouldBeFound("<%= searchBy.fieldName %>.in=" + <%= 'DEFAULT_' + searchBy.fieldNameUnderscored.toUpperCase() %> + "&<%= searchBy.fieldName %>.in=" + <%= 'UPDATED_' + searchBy.fieldNameUnderscored.toUpperCase() %>);
+
+        // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> equals to <%= 'UPDATED_' + searchBy.fieldNameUnderscored.toUpperCase() %>
+        default<%= entityClass %>ShouldNotBeFound("<%= searchBy.fieldName %>.in=" + <%= 'UPDATED_' + searchBy.fieldNameUnderscored.toUpperCase() %>);
+    }
+
+    @Test
+    void getAll<%= entityClassPlural %>By<%= searchBy.fieldInJavaBeanMethod %>IsNullOrNotNull() {
+        // Initialize the database
+        <%= entityInstance %>Repository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(<%= asEntity(entityInstance) %>);
+
+        // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> is not null
+        default<%= entityClass %>ShouldBeFound("<%= searchBy.fieldName %>.specified=true");
+
+        // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> is null
+        default<%= entityClass %>ShouldNotBeFound("<%= searchBy.fieldName %>.specified=false");
+    }
+<%_
+            }
+            if (searchBy.fieldType === 'String') {
+                _%>
+                @Test
+    void getAll<%= entityClassPlural %>By<%= searchBy.fieldInJavaBeanMethod %>ContainsSomething() {
+        // Initialize the database
+        <%= entityInstance %>Repository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(<%= asEntity(entityInstance) %>);
+
+        // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> contains <%= 'DEFAULT_' + searchBy.fieldNameUnderscored.toUpperCase() %>
+        default<%= entityClass %>ShouldBeFound("<%= searchBy.fieldName %>.contains=" + <%= 'DEFAULT_' + searchBy.fieldNameUnderscored.toUpperCase() %>);
+
+        // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> contains <%= 'UPDATED_' + searchBy.fieldNameUnderscored.toUpperCase() %>
+        default<%= entityClass %>ShouldNotBeFound("<%= searchBy.fieldName %>.contains=" + <%= 'UPDATED_' + searchBy.fieldNameUnderscored.toUpperCase() %>);
+    }
+
+    @Test
+    void getAll<%= entityClassPlural %>By<%= searchBy.fieldInJavaBeanMethod %>NotContainsSomething() {
+        // Initialize the database
+        <%= entityInstance %>Repository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(<%= asEntity(entityInstance) %>);
+
+        // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> does not contain <%= 'DEFAULT_' + searchBy.fieldNameUnderscored.toUpperCase() %>
+        default<%= entityClass %>ShouldNotBeFound("<%= searchBy.fieldName %>.doesNotContain=" + <%= 'DEFAULT_' + searchBy.fieldNameUnderscored.toUpperCase() %>);
+
+        // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> does not contain <%= 'UPDATED_' + searchBy.fieldNameUnderscored.toUpperCase() %>
+        default<%= entityClass %>ShouldBeFound("<%= searchBy.fieldName %>.doesNotContain=" + <%= 'UPDATED_' + searchBy.fieldNameUnderscored.toUpperCase() %>);
+    }
+
+<%_
+            }
+            // the range criteria
+            if (['BigDecimal', 'Byte', 'Double', 'Duration', 'Float', 'Short',
+                 'Integer', 'Long', 'LocalDate', 'ZonedDateTime'].includes(searchBy.fieldType)) {
+              var defaultValue = 'DEFAULT_' + searchBy.fieldNameUnderscored.toUpperCase();
+              var biggerValue = 'UPDATED_' + searchBy.fieldNameUnderscored.toUpperCase();
+              var smallerValue = 'SMALLER_' + searchBy.fieldNameUnderscored.toUpperCase();
+              if (searchBy.fieldValidate === true && searchBy.fieldValidateRules.includes('max')) {
+                  // if maximum is specified the updated variable is smaller than the default one!
+                  if (searchBy.fieldType === 'BigDecimal') {
+                      biggerValue = '(' + defaultValue + '.add(BigDecimal.ONE))';
+                  } else if (['Duration', 'LocalDate', 'ZonedDateTime'].includes(searchBy.fieldType)) {
+                      biggerValue = '(' + defaultValue + '.plus(1, ChronoUnit.DAYS))';
+                  } else {
+                      biggerValue = '(' + defaultValue + ' + 1)';
+                  }
+              }
+            _%>
+
+    @Test
+    void getAll<%= entityClassPlural %>By<%= searchBy.fieldInJavaBeanMethod %>IsGreaterThanOrEqualToSomething() {
+        // Initialize the database
+        <%= entityInstance %>Repository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(<%= asEntity(entityInstance) %>);
+
+        // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> is greater than or equal to <%= defaultValue %>
+        default<%= entityClass %>ShouldBeFound("<%= searchBy.fieldName %>.greaterThanOrEqual=" + <%= defaultValue %>);
+
+        // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> is greater than or equal to <%= biggerValue %>
+        default<%= entityClass %>ShouldNotBeFound("<%= searchBy.fieldName %>.greaterThanOrEqual=" + <%= biggerValue %>);
+    }
+
+    @Test
+    void getAll<%= entityClassPlural %>By<%= searchBy.fieldInJavaBeanMethod %>IsLessThanOrEqualToSomething() {
+        // Initialize the database
+        <%= entityInstance %>Repository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(<%= asEntity(entityInstance) %>);
+
+        // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> is less than or equal to <%= defaultValue %>
+        default<%= entityClass %>ShouldBeFound("<%= searchBy.fieldName %>.lessThanOrEqual=" + <%= defaultValue %>);
+
+        // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> is less than or equal to <%= smallerValue %>
+        default<%= entityClass %>ShouldNotBeFound("<%= searchBy.fieldName %>.lessThanOrEqual=" + <%= smallerValue %>);
+    }
+
+    @Test
+    void getAll<%= entityClassPlural %>By<%= searchBy.fieldInJavaBeanMethod %>IsLessThanSomething() {
+        // Initialize the database
+        <%= entityInstance %>Repository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(<%= asEntity(entityInstance) %>);
+
+        // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> is less than <%= defaultValue %>
+        default<%= entityClass %>ShouldNotBeFound("<%= searchBy.fieldName %>.lessThan=" + <%= defaultValue %>);
+
+        // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> is less than <%= biggerValue %>
+        default<%= entityClass %>ShouldBeFound("<%= searchBy.fieldName %>.lessThan=" + <%= biggerValue %>);
+    }
+
+    @Test
+    void getAll<%= entityClassPlural %>By<%= searchBy.fieldInJavaBeanMethod %>IsGreaterThanSomething() {
+        // Initialize the database
+        <%= entityInstance %>Repository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(<%= asEntity(entityInstance) %>);
+
+        // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> is greater than <%= defaultValue %>
+        default<%= entityClass %>ShouldNotBeFound("<%= searchBy.fieldName %>.greaterThan=" + <%= defaultValue %>);
+
+        // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> is greater than <%= smallerValue %>
+        default<%= entityClass %>ShouldBeFound("<%= searchBy.fieldName %>.greaterThan=" + <%= smallerValue %>);
+    }
+
+<%_         } _%>
+<%_     }); _%>
+<%_ relationships.forEach((relationship) => { _%>
+
+    @Test
+    void getAll<%= entityClassPlural %>By<%= relationship.relationshipNameCapitalized %>IsEqualToSomething() {
+        <%_ if ((relationship.relationshipValidate === true && relationship.relationshipType === 'one-to-one') || relationship.useJPADerivedIdentifier === true) { _%>
+        // Get already existing entity
+        <%= asEntity(relationship.otherEntityNameCapitalized) %> <%= relationship.relationshipFieldName %> = <%= asEntity(entityInstance) %>.get<%= relationship.relationshipNameCapitalized %>();
+        <%_ } else { _%>
+        // Initialize the database
+        <%= entityInstance %>Repository.saveAndFlush(<%= asEntity(entityInstance) %>);
+        <%= asEntity(relationship.otherEntityNameCapitalized) %> <%= relationship.relationshipFieldName %> = <%= relationship.otherEntityNameCapitalized %>ResourceIT.createEntity(transactionManager, em);
+        em.persist(<%= relationship.relationshipFieldName %>);
+        em.flush();
+            <%_ if (relationship.relationshipType === 'many-to-many' || relationship.relationshipType === 'one-to-many') { _%>
+        <%= asEntity(entityInstance) %>.add<%= relationship.relationshipNameCapitalized %>(<%= relationship.relationshipFieldName %>);
+            <%_ } else { _%>
+        <%= asEntity(entityInstance) %>.set<%= relationship.relationshipNameCapitalized %>(<%= relationship.relationshipFieldName %>);
+            <%_     if (relationship.ownerSide === false) { _%>
+        <%= relationship.relationshipFieldName %>.set<%= relationship.otherEntityRelationshipNameCapitalized %>(<%= asEntity(entityInstance) %>);
+            <%_     } _%>
+            <%_ } _%>
+        <%_ } _%>
+        <%= entityInstance %>Repository.saveAndFlush(<%= asEntity(entityInstance) %>);
+        <% if (authenticationType === 'oauth2' && relationship.otherEntityName === 'user') { _%>String<%_ } else { _%>Long<% } %> <%= relationship.relationshipFieldName %>Id = <%= relationship.relationshipFieldName %>.getId();
+
+        // Get all the <%= entityInstance %>List where <%= relationship.relationshipFieldName %> equals to <%= relationship.relationshipFieldName %>Id
+        default<%= entityClass %>ShouldBeFound("<%= relationship.relationshipFieldName %>Id.equals=" + <%= relationship.relationshipFieldName %>Id);
+
+        // Get all the <%= entityInstance %>List where <%= relationship.relationshipFieldName %> equals to <%= relationship.relationshipFieldName %>Id + 1
+        default<%= entityClass %>ShouldNotBeFound("<%= relationship.relationshipFieldName %>Id.equals=" + (<%= relationship.relationshipFieldName %>Id + 1));
+    }
+
+<%_ }); _%>
+    /**
+     * Executes the search, and checks that the default entity is returned.
+     */
+    private void default<%= entityClass %>ShouldBeFound(String filter) {
+        List<<%= httpEntityClass %>> <%= entityInstancePlural %> = client.retrieve(HttpRequest.GET("/api/<%= entityApiUrl %>?" + filter), Argument.listOf(<%= httpEntityClass %>.class)).blockingFirst();
+        <%= httpEntityClass %> test<%= entityClass %> = <%= entityInstancePlural %>.get(0);
+<%- include('../../common/validate_entity_fields_template', {isUpdate: false}); -%>
+
+        // Check, that the count call also returns 1
+        Long count = client.retrieve(HttpRequest.GET("/api/<%= entityApiUrl %>/count?" + filter), Long.class).blockingFirst();
+        assertThat(count).isEqualTo(1L);
+    }
+
+    /**
+     * Executes the search, and checks that the default entity is not returned.
+     */
+    private void default<%= entityClass %>ShouldNotBeFound(String filter) {
+        List<<%= httpEntityClass %>> <%= entityInstancePlural %> = client.retrieve(HttpRequest.GET("/api/<%= entityApiUrl %>?" + filter), Argument.listOf(<%= httpEntityClass %>.class)).blockingFirst();
+        assertThat(<%= entityInstancePlural %>).isEmpty();
+
+        // Check, that the count call also returns 0
+        Long count = client.retrieve(HttpRequest.GET("/api/<%= entityApiUrl %>/count?" + filter), Long.class).blockingFirst();
+        assertThat(count).isZero();
     }
 <%_ } _%>
 

--- a/generators/server/files.cjs
+++ b/generators/server/files.cjs
@@ -455,6 +455,22 @@ const serverFiles = {
         },
       ],
     },
+    {
+      condition: generator => generator.databaseType === 'sql',
+      path: SERVER_MAIN_SRC_DIR,
+      templates: [
+        {
+          file: 'package/repository/MHipsterJpaSpecificationExecutor.java',
+          useBluePrint: true,
+          renameTo: generator => `${generator.javaDir}repository/MHipsterJpaSpecificationExecutor.java`,
+        },
+        {
+          file: 'package/repository/SpringDataTypeConverters.java',
+          useBluePrint: true,
+          renameTo: generator => `${generator.javaDir}repository/SpringDataTypeConverters.java`,
+        },
+      ],
+    },
   ],
   serverJavaOpenApi: [
     {

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -412,12 +412,17 @@ dependencies {
     implementation "io.micronaut.micrometer:micronaut-micrometer-core"
     implementation "io.micronaut.micrometer:micronaut-micrometer-registry-prometheus"
     implementation "io.micronaut.data:micronaut-data-runtime:$micronaut_data_version"
+<%_ if (databaseType === 'sql') { _%>
     implementation ("io.micronaut.data:micronaut-data-hibernate-jpa:$micronaut_data_version") {
         exclude group: 'io.micronaut', module: 'micronaut-jdbc'
     }
     implementation("io.micronaut.data:micronaut-data-jdbc:$micronaut_data_version") {
         exclude group: 'io.micronaut', module: 'micronaut-jdbc'
     }
+    implementation "io.micronaut.spring:micronaut-spring"
+    implementation "io.micronaut.data:micronaut-data-spring:$micronaut_data_version"
+    implementation "io.micronaut.data:micronaut-data-spring-jpa:$micronaut_data_version"
+<%_ } _%>
 <%_ if (serviceDiscoveryType === 'eureka' || serviceDiscoveryType === 'consul') { _%>
     implementation "io.micronaut.discovery:micronaut-discovery-client:$micronaut_discovery_client_version"
 <%_ } _%>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -400,6 +400,23 @@ if (devDatabaseType === 'postgresql' || prodDatabaseType === 'postgresql') { _%>
             <artifactId>micronaut-data-runtime</artifactId>
             <scope>compile</scope>
         </dependency>
+<%_ if (databaseType === 'sql') { _%>
+        <dependency>
+            <groupId>io.micronaut.spring</groupId>
+            <artifactId>micronaut-spring</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut.data</groupId>
+            <artifactId>micronaut-data-spring</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut.data</groupId>
+            <artifactId>micronaut-data-spring-jpa</artifactId>
+            <scope>compile</scope>
+        </dependency>
+<%_ } _%>
         <dependency>
             <groupId>io.micronaut</groupId>
             <artifactId>micronaut-http-client</artifactId>

--- a/generators/server/templates/src/main/java/package/repository/MHipsterJpaSpecificationExecutor.java.ejs
+++ b/generators/server/templates/src/main/java/package/repository/MHipsterJpaSpecificationExecutor.java.ejs
@@ -1,0 +1,28 @@
+package <%=packageName%>.repository;
+
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.data.model.Page;
+import io.micronaut.data.model.Pageable;
+import io.micronaut.data.model.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.lang.Nullable;
+
+import java.util.List;
+
+/**
+ * Extension of JpaSpecificationExecutor that uses Micronaut Data Model of Page, Pageable and Sort rather than Spring equivalent.
+ *
+ * @param <T>
+ */
+public interface MHipsterJpaSpecificationExecutor<T> extends JpaSpecificationExecutor<T> {
+
+    default Page<T> findAll(@Nullable Specification<T> specification, Pageable page) {
+        org.springframework.data.domain.Pageable springPageable = ConversionService.SHARED.convertRequired(page, org.springframework.data.domain.Pageable.class);
+        return ConversionService.SHARED.convertRequired(findAll(specification, springPageable), Page.class);
+    }
+
+    default List<T> findAll(@Nullable Specification<T> specification, Sort sort) {
+        return findAll(specification, ConversionService.SHARED.convertRequired(sort, org.springframework.data.domain.Sort.class));
+    }
+}

--- a/generators/server/templates/src/main/java/package/repository/SpringDataTypeConverters.java.ejs
+++ b/generators/server/templates/src/main/java/package/repository/SpringDataTypeConverters.java.ejs
@@ -1,0 +1,71 @@
+package <%=packageName%>.repository;
+
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.convert.TypeConverter;
+import io.micronaut.data.model.Sort;
+
+import javax.inject.Singleton;
+import java.util.Optional;
+
+/**
+ * Provides converters for Micronaut Data Model to Spring Data Domain.
+ */
+@Factory
+@Internal
+public class SpringDataTypeConverters {
+
+    @Singleton
+    TypeConverter<org.springframework.data.domain.Page, io.micronaut.data.model.Page> pageConverter() {
+        return (object, targetType, context) -> Optional.of(io.micronaut.data.model.Page.of(
+            object.getContent(),
+            ConversionService.SHARED.convertRequired(object.getPageable(), io.micronaut.data.model.Pageable.class),
+            object.getTotalElements()
+        ));
+    }
+
+    @Singleton
+    TypeConverter<io.micronaut.data.model.Pageable, org.springframework.data.domain.Pageable> pageableConverter() {
+        return (object, targetType, context) -> {
+            if (object == io.micronaut.data.model.Pageable.UNPAGED) {
+                return Optional.of(org.springframework.data.domain.Pageable.unpaged());
+            }
+            return Optional.of(org.springframework.data.domain.PageRequest.of(
+                object.getNumber(),
+                object.getSize(),
+                ConversionService.SHARED.convertRequired(object.getSort(), org.springframework.data.domain.Sort.class)
+            ));
+        };
+    }
+
+    @Singleton
+    TypeConverter<io.micronaut.data.model.Sort, org.springframework.data.domain.Sort> sortConverter() {
+        return (object, targetType, context) -> {
+            if (object == Sort.UNSORTED) {
+                return Optional.of(org.springframework.data.domain.Sort.unsorted());
+            }
+            return Optional.of(org.springframework.data.domain.Sort.by(
+                object.getOrderBy().stream()
+                    .map(mnSortOrder -> ConversionService.SHARED.convertRequired(mnSortOrder, org.springframework.data.domain.Sort.Order.class))
+                    .toArray(org.springframework.data.domain.Sort.Order[]::new)
+            ));
+        };
+    }
+
+    @Singleton
+    TypeConverter<io.micronaut.data.model.Sort.Order, org.springframework.data.domain.Sort.Order> sortOrderConverter() {
+        return (object, targetType, context) -> {
+            org.springframework.data.domain.Sort.Order springOrder = org.springframework.data.domain.Sort.Order.by(object.getProperty());
+            if (object.isIgnoreCase()) {
+                springOrder = springOrder.ignoreCase();
+            }
+            if (object.isAscending()) {
+                springOrder = springOrder.with(org.springframework.data.domain.Sort.Direction.ASC);
+            } else {
+                springOrder = springOrder.with(org.springframework.data.domain.Sort.Direction.DESC);
+            }
+            return Optional.of(springOrder);
+        };
+    }
+}

--- a/generators/server/templates/src/test/resources/application-test.yml.ejs
+++ b/generators/server/templates/src/test/resources/application-test.yml.ejs
@@ -1,10 +1,15 @@
 datasources:
   default:
+    type: com.zaxxer.hikari.HikariDataSource
     url: jdbc:h2:mem:<%= lowercaseBaseName %>;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     username: <%= baseName %>
     password: ''
+    driverClassName: 'org.h2.Driver'
     poolName: Hikari
     autoCommit: false
+    hikari:
+      poolName: Hikari
+      maximum-pool-size: 10
 
 <%_ if (serviceDiscoveryType === 'consul') { _%>
 consul:

--- a/test-integration/samples/mvn-jwt-angular.jdl
+++ b/test-integration/samples/mvn-jwt-angular.jdl
@@ -60,3 +60,5 @@ relationship ManyToMany {
 }
 
 paginate Operation with infinite-scroll
+filter Operation
+service Operation with serviceClass


### PR DESCRIPTION
Fixes #171

It should be noted that the behavior of `xyz.in=someValue,otherValue` in REST query params is not supported (see https://github.com/micronaut-projects/micronaut-core/issues/2157), so instead `xyz.in=someValue&xyz.in=otherValue` should be used