### PR TITLE
Removes temporary Liquibase resolution strategy in Gradle builds (#192)

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -253,15 +253,6 @@ configurations {
     providedRuntime
 }
 
-<%_ if (databaseType === 'sql') { _%>
-    // This is due to a conflict between JHipster and Micronaut Liquibase
-    // When micronaut-liquibase supports a version higher than 3.8.0
-    // this can likely be removed
-    configurations.all {
-        resolutionStrategy.force 'org.liquibase:liquibase-core:3.8.9'
-    }
-<%_ } _%>
-
 repositories {
     mavenLocal()
     mavenCentral()


### PR DESCRIPTION
Closes #192 