### PR TITLE
remove jcenter repo from maven and gradle build file

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -256,7 +256,14 @@ configurations {
 repositories {
     mavenLocal()
     mavenCentral()
-    jcenter()
+    <%_ if (JHIPSTER_DEPENDENCIES_VERSION.endsWith('-SNAPSHOT')) { _%>
+    maven {
+        url "https://oss.sonatype.org/content/repositories/snapshots/"
+        mavenContent {
+            snapshotsOnly()
+        }
+    }
+    <%_ } _%>
     //jhipster-needle-gradle-repositories - JHipster will add additional repositories
 }
 

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -14,10 +14,6 @@ _%>
 
     <repositories>
         <!-- jhipster-needle-maven-repository -->
-        <repository>
-            <id>jcenter</id>
-            <url>https://jcenter.bintray.com</url>
-        </repository>
         <%_ if (JHIPSTER_DEPENDENCIES_VERSION.endsWith('-SNAPSHOT')) { _%>
         <repository>
             <id>ossrh-snapshots</id>


### PR DESCRIPTION
This removes jcenter definition from pom.xml and build.gradle. Everything should be on central I think.

updates #223