### PR TITLE
Fix #71: Support Reactive Applications

### DIFF
--- a/generators/micronaut/__snapshots__/generator.spec.js.snap
+++ b/generators/micronaut/__snapshots__/generator.spec.js.snap
@@ -1470,6 +1470,533 @@ exports[`SubGenerator server of micronaut JHipster blueprint > with maven build 
 }
 `;
 
+exports[`SubGenerator server of micronaut JHipster blueprint > with reactive entities > should succeed 1`] = `
+{
+  ".editorconfig": {
+    "stateCleared": "modified",
+  },
+  ".gitattributes": {
+    "stateCleared": "modified",
+  },
+  ".gitignore": {
+    "stateCleared": "modified",
+  },
+  ".husky/pre-commit": {
+    "stateCleared": "modified",
+  },
+  ".jhipster/Entity.json": {
+    "stateCleared": "modified",
+  },
+  ".lintstagedrc.cjs": {
+    "stateCleared": "modified",
+  },
+  ".mvn/jvm.config": {
+    "stateCleared": "modified",
+  },
+  ".mvn/wrapper/maven-wrapper.jar": {
+    "stateCleared": "modified",
+  },
+  ".mvn/wrapper/maven-wrapper.properties": {
+    "stateCleared": "modified",
+  },
+  ".prettierignore": {
+    "stateCleared": "modified",
+  },
+  ".prettierrc": {
+    "stateCleared": "modified",
+  },
+  ".yo-rc.json": {
+    "stateCleared": "modified",
+  },
+  "README.md": {
+    "stateCleared": "modified",
+  },
+  "checkstyle.xml": {
+    "stateCleared": "modified",
+  },
+  "mvnw": {
+    "stateCleared": "modified",
+  },
+  "mvnw.cmd": {
+    "stateCleared": "modified",
+  },
+  "npmw": {
+    "stateCleared": "modified",
+  },
+  "npmw.cmd": {
+    "stateCleared": "modified",
+  },
+  "package.json": {
+    "stateCleared": "modified",
+  },
+  "pom.xml": {
+    "stateCleared": "modified",
+  },
+  "sonar-project.properties": {
+    "stateCleared": "modified",
+  },
+  "src/main/docker/app.yml": {
+    "stateCleared": "modified",
+  },
+  "src/main/docker/grafana/provisioning/dashboards/JVM.json": {
+    "stateCleared": "modified",
+  },
+  "src/main/docker/grafana/provisioning/dashboards/dashboard.yml": {
+    "stateCleared": "modified",
+  },
+  "src/main/docker/grafana/provisioning/datasources/datasource.yml": {
+    "stateCleared": "modified",
+  },
+  "src/main/docker/jhipster-control-center.yml": {
+    "stateCleared": "modified",
+  },
+  "src/main/docker/jib/entrypoint.sh": {
+    "stateCleared": "modified",
+  },
+  "src/main/docker/monitoring.yml": {
+    "stateCleared": "modified",
+  },
+  "src/main/docker/postgresql.yml": {
+    "stateCleared": "modified",
+  },
+  "src/main/docker/prometheus/prometheus.yml": {
+    "stateCleared": "modified",
+  },
+  "src/main/docker/services.yml": {
+    "stateCleared": "modified",
+  },
+  "src/main/docker/sonar.yml": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/GeneratedByJHipster.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/JhipsterApp.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/config/ActiveProfilesInfoSource.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/config/ApplicationProperties.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/config/Constants.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/config/DefaultProfileUtil.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/config/JHipsterConfigurationEndpoint.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/config/JacksonConfiguration.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/config/LoggingConfiguration.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/config/MessagesBundleMessageSource.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/config/SnakeCasePhysicalNamingStrategy.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/config/metric/JHipsterMetricsEndpoint.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/config/metric/package-info.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/config/package-info.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/domain/Authority.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/domain/Entity.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/domain/User.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/domain/package-info.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/package-info.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/repository/AuthorityRepository.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/repository/EntityRepository.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/repository/UserRepository.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/repository/package-info.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/security/AuthoritiesConstants.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/security/BcryptPasswordEncoder.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/security/DatabaseAuthenticationProvider.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/security/Logout.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/security/NotAuthenticatedResponse.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/security/PasswordEncoder.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/security/SecurityHeaderFilter.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/security/SecurityUtils.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/security/UserNotActivatedException.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/security/package-info.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/service/EntityService.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/service/MailSenderFactory.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/service/MailService.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/service/UserService.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/service/dto/AdminUserDTO.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/service/dto/EntityDTO.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/service/dto/PasswordChangeDTO.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/service/dto/UserDTO.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/service/dto/package-info.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/service/impl/EntityServiceImpl.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/service/impl/package-info.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/service/mapper/EntityMapper.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/service/mapper/UserMapper.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/service/mapper/package-info.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/service/package-info.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/service/util/RandomUtil.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/service/util/package-info.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/util/HeaderUtil.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/util/JHipsterProperties.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/util/PaginationUtil.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/util/package-info.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/web/rest/AccountResource.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/web/rest/ClientForwardController.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/web/rest/EntityResource.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/web/rest/PublicUserResource.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/web/rest/SwaggerResource.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/web/rest/UserResource.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/web/rest/errors/BadRequestAlertException.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/web/rest/errors/EmailAlreadyUsedException.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/web/rest/errors/EmailNotFoundException.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/web/rest/errors/ErrorConstants.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/web/rest/errors/FieldErrorVM.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/web/rest/errors/InvalidPasswordException.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/web/rest/errors/LoginAlreadyUsedException.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/web/rest/errors/handlers/AbstractThrowableProblemHandler.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/web/rest/errors/handlers/ConstraintViolationExceptionHandler.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/web/rest/errors/handlers/ProblemHandler.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/web/rest/errors/handlers/ProblemRejectionHandler.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/web/rest/errors/handlers/UnsatisfiedRouteExceptionHandler.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/web/rest/errors/handlers/package-info.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/web/rest/errors/package-info.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/web/rest/package-info.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/web/rest/vm/KeyAndPasswordVM.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/web/rest/vm/LoginVM.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/web/rest/vm/ManagedUserVM.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/web/rest/vm/package-info.java": {
+    "stateCleared": "modified",
+  },
+  "src/main/resources/application-dev.yml": {
+    "stateCleared": "modified",
+  },
+  "src/main/resources/application-prod.yml": {
+    "stateCleared": "modified",
+  },
+  "src/main/resources/application-tls.yml": {
+    "stateCleared": "modified",
+  },
+  "src/main/resources/application.yml": {
+    "stateCleared": "modified",
+  },
+  "src/main/resources/bootstrap.yml": {
+    "stateCleared": "modified",
+  },
+  "src/main/resources/config/liquibase/changelog/00000000000000_initial_schema.xml": {
+    "stateCleared": "modified",
+  },
+  "src/main/resources/config/liquibase/changelog/20200804035352_added_entity_Entity.xml": {
+    "stateCleared": "modified",
+  },
+  "src/main/resources/config/liquibase/data/authority.csv": {
+    "stateCleared": "modified",
+  },
+  "src/main/resources/config/liquibase/data/user.csv": {
+    "stateCleared": "modified",
+  },
+  "src/main/resources/config/liquibase/data/user_authority.csv": {
+    "stateCleared": "modified",
+  },
+  "src/main/resources/config/liquibase/fake-data/entity.csv": {
+    "stateCleared": "modified",
+  },
+  "src/main/resources/config/liquibase/master.xml": {
+    "stateCleared": "modified",
+  },
+  "src/main/resources/i18n/messages.properties": {
+    "stateCleared": "modified",
+  },
+  "src/main/resources/i18n/messages_en.properties": {
+    "stateCleared": "modified",
+  },
+  "src/main/resources/logback.xml": {
+    "stateCleared": "modified",
+  },
+  "src/main/resources/views/error.html": {
+    "stateCleared": "modified",
+  },
+  "src/main/resources/views/mail/activationEmail.html": {
+    "stateCleared": "modified",
+  },
+  "src/main/resources/views/mail/creationEmail.html": {
+    "stateCleared": "modified",
+  },
+  "src/main/resources/views/mail/passwordResetEmail.html": {
+    "stateCleared": "modified",
+  },
+  "src/main/resources/views/mail/testEmail.html": {
+    "stateCleared": "modified",
+  },
+  "src/main/webapp/i18n/en/activate.json": {
+    "stateCleared": "modified",
+  },
+  "src/main/webapp/i18n/en/configuration.json": {
+    "stateCleared": "modified",
+  },
+  "src/main/webapp/i18n/en/entity.json": {
+    "stateCleared": "modified",
+  },
+  "src/main/webapp/i18n/en/error.json": {
+    "stateCleared": "modified",
+  },
+  "src/main/webapp/i18n/en/global.json": {
+    "stateCleared": "modified",
+  },
+  "src/main/webapp/i18n/en/health.json": {
+    "stateCleared": "modified",
+  },
+  "src/main/webapp/i18n/en/home.json": {
+    "stateCleared": "modified",
+  },
+  "src/main/webapp/i18n/en/login.json": {
+    "stateCleared": "modified",
+  },
+  "src/main/webapp/i18n/en/logs.json": {
+    "stateCleared": "modified",
+  },
+  "src/main/webapp/i18n/en/metrics.json": {
+    "stateCleared": "modified",
+  },
+  "src/main/webapp/i18n/en/password.json": {
+    "stateCleared": "modified",
+  },
+  "src/main/webapp/i18n/en/register.json": {
+    "stateCleared": "modified",
+  },
+  "src/main/webapp/i18n/en/reset.json": {
+    "stateCleared": "modified",
+  },
+  "src/main/webapp/i18n/en/sessions.json": {
+    "stateCleared": "modified",
+  },
+  "src/main/webapp/i18n/en/settings.json": {
+    "stateCleared": "modified",
+  },
+  "src/main/webapp/i18n/en/user-management.json": {
+    "stateCleared": "modified",
+  },
+  "src/test/java/com/mycompany/myapp/config/CorsController.java": {
+    "stateCleared": "modified",
+  },
+  "src/test/java/com/mycompany/myapp/config/CorsTest.java": {
+    "stateCleared": "modified",
+  },
+  "src/test/java/com/mycompany/myapp/domain/AssertUtils.java": {
+    "stateCleared": "modified",
+  },
+  "src/test/java/com/mycompany/myapp/domain/EntityAsserts.java": {
+    "stateCleared": "modified",
+  },
+  "src/test/java/com/mycompany/myapp/domain/EntityTest.java": {
+    "stateCleared": "modified",
+  },
+  "src/test/java/com/mycompany/myapp/domain/EntityTestSamples.java": {
+    "stateCleared": "modified",
+  },
+  "src/test/java/com/mycompany/myapp/security/DomainUserDetailsServiceIT.java": {
+    "stateCleared": "modified",
+  },
+  "src/test/java/com/mycompany/myapp/security/SecurityHeaderFilterTest.java": {
+    "stateCleared": "modified",
+  },
+  "src/test/java/com/mycompany/myapp/security/SecurityUtilsUnitTest.java": {
+    "stateCleared": "modified",
+  },
+  "src/test/java/com/mycompany/myapp/security/jwt/JWTFilterTest.java": {
+    "stateCleared": "modified",
+  },
+  "src/test/java/com/mycompany/myapp/service/MailServiceIT.java": {
+    "stateCleared": "modified",
+  },
+  "src/test/java/com/mycompany/myapp/service/UserServiceIT.java": {
+    "stateCleared": "modified",
+  },
+  "src/test/java/com/mycompany/myapp/service/dto/EntityDTOTest.java": {
+    "stateCleared": "modified",
+  },
+  "src/test/java/com/mycompany/myapp/service/mapper/EntityMapperTest.java": {
+    "stateCleared": "modified",
+  },
+  "src/test/java/com/mycompany/myapp/service/mapper/UserMapperIT.java": {
+    "stateCleared": "modified",
+  },
+  "src/test/java/com/mycompany/myapp/web/rest/AccountResourceIT.java": {
+    "stateCleared": "modified",
+  },
+  "src/test/java/com/mycompany/myapp/web/rest/ClientForwardControllerIT.java": {
+    "stateCleared": "modified",
+  },
+  "src/test/java/com/mycompany/myapp/web/rest/TestUtil.java": {
+    "stateCleared": "modified",
+  },
+  "src/test/java/com/mycompany/myapp/web/rest/UserJWTControllerIT.java": {
+    "stateCleared": "modified",
+  },
+  "src/test/java/com/mycompany/myapp/web/rest/UserResourceIT.java": {
+    "stateCleared": "modified",
+  },
+  "src/test/java/com/mycompany/myapp/web/rest/errors/ExceptionTranslatorIT.java": {
+    "stateCleared": "modified",
+  },
+  "src/test/java/com/mycompany/myapp/web/rest/errors/ExceptionTranslatorTestController.java": {
+    "stateCleared": "modified",
+  },
+  "src/test/java/com/mycompany/myapp/web/rest/errors/TestDTO.java": {
+    "stateCleared": "modified",
+  },
+  "src/test/resources/application-test.yml": {
+    "stateCleared": "modified",
+  },
+  "src/test/resources/bootstrap-test.yml": {
+    "stateCleared": "modified",
+  },
+  "src/test/resources/i18n/messages_en.properties": {
+    "stateCleared": "modified",
+  },
+  "src/test/resources/logback.xml": {
+    "stateCleared": "modified",
+  },
+}
+`;
+
 exports[`SubGenerator server of micronaut JHipster blueprint > with some entities > should succeed 1`] = `
 {
   ".editorconfig": {

--- a/generators/micronaut/entity-files.js
+++ b/generators/micronaut/entity-files.js
@@ -83,11 +83,6 @@ export const entityFiles = {
       relativePath: '_entityPackage_/',
       templates: ['repository/search/_entityClass_SearchRepositoryMockConfiguration.java'],
     }),
-    javaMainPackageTemplatesBlock({
-      condition: generator => generator.reactive && ['mongodb', 'cassandra', 'couchbase'].includes(generator.databaseType),
-      relativePath: '_entityPackage_/',
-      templates: ['repository/reactive/_entityClass_ReactiveRepository.java'],
-    }),
   ],
   mapstruct: [
     javaMainPackageTemplatesBlock({

--- a/generators/micronaut/generator.spec.js
+++ b/generators/micronaut/generator.spec.js
@@ -58,6 +58,43 @@ describe('SubGenerator server of micronaut JHipster blueprint', () => {
     });
   });
 
+  describe('with reactive entities', () => {
+    beforeAll(async function () {
+      await helpers
+        .run(BLUEPRINT_NAMESPACE)
+        .withJHipsterConfig(
+          {
+            reactive: true,
+            creationTimestamp: 1596513172471,
+          },
+          [
+            {
+              name: 'Entity',
+              service: 'serviceImpl',
+              dto: 'mapstruct',
+              fields: [
+                {
+                  fieldName: 'name',
+                  fieldType: 'String',
+                },
+              ],
+            },
+          ],
+        )
+        .withOptions({
+          reproducible: true,
+          ignoreNeedlesError: true,
+          blueprint: 'micronaut',
+        })
+        .withJHipsterLookup()
+        .withParentBlueprintLookup();
+    });
+
+    it('should succeed', () => {
+      expect(result.getStateSnapshot()).toMatchSnapshot();
+    });
+  });
+
   describe('with gradle build tool', () => {
     beforeAll(async function () {
       await helpers

--- a/generators/micronaut/templates/src/main/java/_package_/_entityPackage_/partials_entity/get_all_template.ejs
+++ b/generators/micronaut/templates/src/main/java/_package_/_entityPackage_/partials_entity/get_all_template.ejs
@@ -24,7 +24,7 @@
     const entityToDtoReference = mapper + '::'+ 'toDto';
 _%>
 <%_ if (jpaMetamodelFiltering) { _%>
-    public HttpResponse<List<<%= instanceType %>>> getAll<%= entityClassPlural %>(<%= entityClass %>Criteria criteria<% if (pagination != 'no') { %>, Pageable pageable<% if (reactive) { %>, HttpRequest request<% } %><% } %>) {
+    public HttpResponse<List<<%= instanceType %>>> getAll<%= entityClassPlural %>(<%= entityClass %>Criteria criteria<% if (pagination != 'no') { %>, Pageable pageable, HttpRequest request<% } %>) {
         log.debug("REST request to get <%= entityClassPlural %> by criteria: {}", criteria);
     <%_ if (pagination === 'no') { _%>
         List<<%= instanceType %>> entityList = <%= entityInstance %>QueryService.findByCriteria(criteria);
@@ -32,7 +32,7 @@ _%>
     <%_ } else { _%>
         Page<<%= instanceType %>> page = <%= entityInstance %>QueryService.findByCriteria(criteria, pageable);
         return HttpResponse.ok(page.getContent()).headers(headers ->
-            PaginationUtil.generatePaginationHttpHeaders(<% if (!reactive) { %>headers, UriBuilder.of(request.getPath())<% } else { %>UriComponentsBuilder.fromHttpRequest(request)<% } %>, page));
+            PaginationUtil.generatePaginationHttpHeaders(headers, UriBuilder.of(request.getPath()), page));
     <%_ } _%>
     }
 
@@ -80,9 +80,9 @@ _%>
         <%_ } else { _%>
         Page<<%= instanceType %>> page = <%= entityInstance %>Repository.findAll(pageable)<% if (dto !== 'mapstruct') { %>;<% } else { %>.map(<%= entityToDtoReference %>);<% } %>
         <%_ } _%>
-    <%_ } _%>
+        <%_ } _%>
         return HttpResponse.ok(page.getContent()).headers(headers ->
-            PaginationUtil.generatePaginationHttpHeaders(<% if (!reactive) { %>headers, UriBuilder.of(request.getPath())<% } else { %>UriComponentsBuilder.fromHttpRequest(request)<% } %>, page));
+            PaginationUtil.generatePaginationHttpHeaders(headers, UriBuilder.of(request.getPath()), page));
     <%_ } _%>
     }
 <%_ } _%>

--- a/generators/micronaut/templates/src/main/java/_package_/_entityPackage_/partials_entity/inject_template.ejs
+++ b/generators/micronaut/templates/src/main/java/_package_/_entityPackage_/partials_entity/inject_template.ejs
@@ -36,9 +36,6 @@
         if (searchEngine === 'elasticsearch') {
             beans.push({class: `${entityClass}SearchRepository`, instance: `${entityInstance}SearchRepository`});
         }
-        if (reactive) {
-            beans.push({class: `${entityClass}ReactiveRepository`, instance: `${entityInstance}ReactiveRepository`});
-        }
         if (isUsingMapsId === true) {
             const mapsIdEntity = mapsIdAssoc.otherEntityNameCapitalized;
             const mapsIdEntityInstance = mapsIdEntity.charAt(0).toLowerCase() + mapsIdEntity.slice(1);

--- a/generators/micronaut/templates/src/main/java/_package_/_entityPackage_/partials_entity/search_template.ejs
+++ b/generators/micronaut/templates/src/main/java/_package_/_entityPackage_/partials_entity/search_template.ejs
@@ -26,11 +26,11 @@
     public List<<%= instanceType %>> search<%= entityClassPlural %>(@RequestParam String query) {
         log.debug("REST request to search <%= entityClassPlural %> for query {}", query);<%- include('search_stream_template', {viaService: viaService}); -%>
     <% } if (pagination !== 'no') { %>
-    public HttpResponse<List<<%= instanceType %>>> search<%= entityClassPlural %>(@RequestParam String query, Pageable pageable<% if (reactive) { %>, ServerHttpRequest request<% } %>) {
+    public HttpResponse<List<<%= instanceType %>>> search<%= entityClassPlural %>(@RequestParam String query, Pageable pageable, HttpRequest request) {
         log.debug("REST request to search for a page of <%= entityClassPlural %> for query {}", query);<% if (viaService) { %>
         Page<<%= instanceType %>> page = <%= entityInstance %>Service.search(query, pageable);<% } else { %>
         Page<<%= persistClass %>> page = <%= entityInstance %>SearchRepository.search(queryStringQuery(query), pageable);<% } %>
-        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(<% if (!reactive) { %>headers, UriBuilder.of(request.getPath())<% } else { %>UriComponentsBuilder.fromHttpRequest(request)<% } %>, page);
-        return HttpResponse.ok().headers(headers).body(<% if (!viaService && dto === 'mapstruct') { %><%= entityListToDtoListReference %>(<% } %>page.getContent()<% if (!viaService && dto === 'mapstruct') { %>)<% } %>);
+        return HttpResponse.ok(<% if (!viaService && dto === 'mapstruct') { %><%= entityListToDtoListReference %>(<% } %>page.getContent()<% if (!viaService && dto === 'mapstruct') { %>)<% } %>).headers(headers ->
+            PaginationUtil.generatePaginationHttpHeaders(headers, UriBuilder.of(request.getPath()), page));
     <% } -%>
 }

--- a/generators/micronaut/templates/src/main/java/_package_/_entityPackage_/service/impl/_entityClass_ServiceImpl.java.ejs
+++ b/generators/micronaut/templates/src/main/java/_package_/_entityPackage_/service/impl/_entityClass_ServiceImpl.java.ejs
@@ -48,9 +48,6 @@ import <%= packageName %>.repository.<%= entityClass %>Repository;
 <%_ if (isUsingMapsId === true) { _%>
 import <%= packageName %>.repository.<%= mapsIdAssoc.otherEntityNameCapitalized %>Repository;
 <%_ } _%>
-<%_ if (reactive) { _%>
-import <%= packageName %>.repository.reactive.<%= entityClass %>ReactiveRepository;
-<%_ } _%>
 <%_ if (searchEngine === 'elasticsearch') { _%>
 import <%= packageName %>.repository.search.<%= entityClass %>SearchRepository;
 <%_ } _%>
@@ -165,7 +162,7 @@ public class <%= serviceClassName %><% if (service === 'serviceImpl') { %> imple
      */
     public Flux<<%= instanceType %>> findAllAsFlux() {
         log.debug("Request to get all <%= entityClassPlural %> as a flux");
-        return <%= entityInstance %>ReactiveRepository.findAll()<% if (dto === 'mapstruct') { %>
+        return Flux.fromIterable(<%= entityInstance %>Repository.findAll())<% if (dto === 'mapstruct') { %>
             .map(<%= entityToDtoReference %>)<% } %>;
     }
     <%_ } _%>

--- a/generators/micronaut/templates/src/main/java/_package_/_entityPackage_/web/rest/_entityClass_Resource.java.ejs
+++ b/generators/micronaut/templates/src/main/java/_package_/_entityPackage_/web/rest/_entityClass_Resource.java.ejs
@@ -48,9 +48,6 @@ import <%= packageName %>.repository.<%= entityClass %>Repository;
     <%_ if (isUsingMapsId === true) { _%>
 import <%= packageName %>.repository.<%= mapsIdAssoc.otherEntityNameCapitalized %>Repository;
     <%_ } _%>
-    <%_ if (reactive) { _%>
-import <%= packageName %>.repository.reactive.<%= entityClass %>ReactiveRepository;
-    <%_ } _%>
     <%_ if (searchEngine === 'elasticsearch') { _%>
 import <%= packageName %>.repository.search.<%= entityClass %>SearchRepository;
     <%_ } _%>
@@ -89,19 +86,6 @@ import org.slf4j.LoggerFactory;
 import io.micronaut.data.model.Page;
 import io.micronaut.data.model.Pageable;
 import io.micronaut.transaction.annotation.ReadOnly;
-<%# import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus; %>
-    <%_ if (reactive) { _%>
-<%# import org.springframework.http.server.reactive.ServerHttpRequest; %>
-    <%_ } _%>
-    <%_ if (!reactive) { _%>
-<%# import org.springframework.web.servlet.support.ServletUriComponentsBuilder; %>
-    <%_ } else { _%>
-<%# import org.springframework.web.util.UriComponentsBuilder; %>
-    <%_ } _%>
-<%_ } _%>
-<%_ if (reactive) { _%>
-<%# import org.springframework.http.MediaType; %>
 <%_ } _%>
 <%# import org.springframework.http.HttpResponse; %>
 <%_ if (!viaService && !saveUserSnapshot) { _%>
@@ -241,9 +225,7 @@ public class <%= entityClass %>Resource {
      *
     <%_ if (pagination !== 'no') { _%>
      * @param pageable the pagination information.
-        <%_ if (reactive) { _%>
-     * @param request a {@link ServerHttpRequest} request.
-        <%_ } _%>
+     * @param request the current request.
     <%_ } _%>
     <%_ if (!jpaMetamodelFiltering && fieldsContainOwnerManyToMany) { _%>
      * @param eagerload flag to eager load entities from relationships (This is applicable for many-to-many).
@@ -268,7 +250,7 @@ public class <%= entityClass %>Resource {
      * {@code GET  /<%= entityApiUrl %>} : get all the <%= entityInstancePlural %> as a stream.
      * @return the {@link Flux} of <%= entityInstancePlural %>.
      */
-    @Get(value = "/<%= entityApiUrl %>", produces = MediaType.APPLICATION_STREAM_JSON_VALUE)
+    @Get(value = "/<%= entityApiUrl %>", produces = "application/x-ndjson")
     @ExecuteOn(TaskExecutors.IO)
     <%_ if (databaseTypeSql && isUsingMapsId === true && !viaService) { _%>
     @ReadOnly
@@ -279,7 +261,8 @@ public class <%= entityClass %>Resource {
         <%_ if (viaService) { _%>
         return <%= entityInstance %>Service.findAllAsFlux();
         <%_ } else { _%>
-        return <%= entityInstance %>ReactiveRepository.findAll();
+        return Flux.fromIterable(<%= entityInstance %>Repository.findAll())<% if (dto === 'mapstruct') { %>
+            .map(<%= entityInstance %>Mapper::toDto)<% } %>;
         <%_ } _%>
     }
 
@@ -325,9 +308,7 @@ public class <%= entityClass %>Resource {
      * @param query the query of the <%= entityInstance %> search.
     <%_ if (pagination !== 'no') { _%>
      * @param pageable the pagination information.
-       <%_ if (reactive) { _%>
-     * @param request a {@link ServerHttpRequest} request.
-        <%_ } _%>
+     * @param request the current request.
     <%_ } _%>
      * @return the result of the search.
      */


### PR DESCRIPTION
## Summary

This PR resolves #71.

### Changes

Implemented reactive-application template support fixes by removing broken Spring reactive repository generation/wiring, replacing reactive entity streaming with Micronaut-compatible Flux generation from existing repositories/services, and fixing pagination/search request/header generation to use HttpRequest + UriBuilder. Added a reactive-entity generator snapshot test.

### Files Modified

- `generators/micronaut/entity-files.js`
- `generators/micronaut/generator.spec.js`
- `generators/micronaut/__snapshots__/generator.spec.js.snap`
- `generators/micronaut/templates/src/main/java/_package_/_entityPackage_/partials_entity/inject_template.ejs`
- `generators/micronaut/templates/src/main/java/_package_/_entityPackage_/partials_entity/get_all_template.ejs`
- `generators/micronaut/templates/src/main/java/_package_/_entityPackage_/partials_entity/search_template.ejs`
- `generators/micronaut/templates/src/main/java/_package_/_entityPackage_/service/impl/_entityClass_ServiceImpl.java.ejs`
- `generators/micronaut/templates/src/main/java/_package_/_entityPackage_/web/rest/_entityClass_Resource.java.ejs`

Happy to address any feedback or make adjustments.

/claim #71