### PR TITLE
feat: add Hazelcast cache provider support

### DIFF
--- a/generators/micronaut-cache/__snapshots__/generator.spec.js.snap
+++ b/generators/micronaut-cache/__snapshots__/generator.spec.js.snap
@@ -10,3 +10,14 @@ exports[`SubGenerator micronaut-cache of micronaut JHipster blueprint > run > sh
   },
 }
 `;
+
+exports[`SubGenerator micronaut-cache of micronaut JHipster blueprint > run with hazelcast cache provider > should succeed 1`] = `
+{
+  ".yo-rc.json": {
+    "stateCleared": "modified",
+  },
+  "src/main/java/com/mycompany/myapp/config/CacheConfiguration.java": {
+    "stateCleared": "modified",
+  },
+}
+`;

--- a/generators/micronaut-cache/generator.js
+++ b/generators/micronaut-cache/generator.js
@@ -20,7 +20,7 @@ export default class extends BaseApplicationGenerator {
   get [BaseApplicationGenerator.PREPARING]() {
     return this.asPreparingTaskGroup({
       addNeedles({ source, application }) {
-        if (application.cacheProviderEhcache || application.cacheProviderCaffeine || application.cacheProviderRedis) {
+        if (application.cacheProviderEhcache || application.cacheProviderCaffeine || application.cacheProviderHazelcast || application.cacheProviderRedis) {
           const cacheConfigurationFile = `${application.javaPackageSrcDir}config/CacheConfiguration.java`;
           const needle = `${application.cacheProvider}-add-entry`;
           const addEntryToCacheCallback = entry =>
@@ -74,7 +74,7 @@ export default class extends BaseApplicationGenerator {
       },
       customizeFiles({ source, entities, application: { cacheProvider, enableHibernateCache } }) {
         if (!enableHibernateCache || !cacheProvider) return;
-        if (['ehcache', 'caffeine', 'infinispan', 'redis'].includes(cacheProvider)) {
+        if (['ehcache', 'caffeine', 'hazelcast', 'infinispan', 'redis'].includes(cacheProvider)) {
           for (const entity of entities.filter(entity => !entity.skipServer && !entity.builtIn)) {
             const { entityAbsoluteClass } = entity;
             source.addEntityToCache?.({

--- a/generators/micronaut-cache/generator.spec.js
+++ b/generators/micronaut-cache/generator.spec.js
@@ -22,4 +22,37 @@ describe('SubGenerator micronaut-cache of micronaut JHipster blueprint', () => {
       expect(result.getStateSnapshot()).toMatchSnapshot();
     });
   });
+
+  describe('run with hazelcast cache provider', () => {
+    beforeAll(async function () {
+      await helpers
+        .run(SUB_GENERATOR_NAMESPACE)
+        .withJHipsterConfig({
+          cacheProvider: 'hazelcast',
+        })
+        .withOptions({
+          ignoreNeedlesError: true,
+        })
+        .withJHipsterLookup()
+        .withParentBlueprintLookup();
+    });
+
+    it('should succeed', () => {
+      expect(result.getStateSnapshot()).toMatchSnapshot();
+    });
+
+    it('should generate CacheConfiguration with hazelcast imports', () => {
+      result.assertFileContent(
+        'src/main/java/com/mycompany/myapp/config/CacheConfiguration.java',
+        'com.hazelcast.config.Config',
+      );
+    });
+
+    it('should generate hazelcast needle comment', () => {
+      result.assertFileContent(
+        'src/main/java/com/mycompany/myapp/config/CacheConfiguration.java',
+        'jhipster-needle-hazelcast-add-entry',
+      );
+    });
+  });
 });

--- a/generators/micronaut-cache/templates/src/main/java/_package_/config/CacheConfiguration.java.ejs
+++ b/generators/micronaut-cache/templates/src/main/java/_package_/config/CacheConfiguration.java.ejs
@@ -18,6 +18,15 @@ import com.github.benmanes.caffeine.jcache.configuration.CaffeineConfiguration;
 import java.util.OptionalLong;
 import java.util.concurrent.TimeUnit;
 <%_ } _%>
+<%_ if (cacheProvider === 'hazelcast') { _%>
+import com.hazelcast.config.Config;
+import com.hazelcast.config.EvictionConfig;
+import com.hazelcast.config.EvictionPolicy;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MaxSizePolicy;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+<%_ } _%>
 <%_ if (cacheProvider === 'redis') { _%>
 import java.net.URI;
 import org.redisson.Redisson;
@@ -62,6 +71,19 @@ public class CacheConfiguration {
         caffeineConfiguration.setExpireAfterWrite(OptionalLong.of(TimeUnit.SECONDS.toNanos(caffeine.getTimeToLiveSeconds())));
         caffeineConfiguration.setStatisticsEnabled(true);
         jcacheConfiguration = caffeineConfiguration;
+        <%_ } else if (cacheProvider === 'hazelcast') { _%>
+        JHipsterProperties.Cache.Hazelcast hazelcast =
+            jHipsterProperties.getCache().getHazelcast();
+
+        Config config = new Config();
+        config.getMapConfig("default")
+            .setBackupCount(hazelcast.getBackupCount())
+            .setEvictionConfig(new EvictionConfig()
+                .setMaxSizePolicy(MaxSizePolicy.PER_NODE)
+                .setSize(hazelcast.getManagementCenter().isEnabled() ? 200 : 100)
+                .setEvictionPolicy(EvictionPolicy.LRU))
+            .setTimeToLiveSeconds(hazelcast.getTimeToLiveSeconds());
+        jcacheConfiguration = null;
         <%_ } else if (cacheProvider === 'redis') { _%>
         MutableConfiguration<Object, Object> jcacheConfig = new MutableConfiguration<>();
 
@@ -109,6 +131,9 @@ public class CacheConfiguration {
         <%_ } else if (cacheProvider === 'caffeine') { _%>
         CacheManager cacheManager = new CaffeineCachingProvider().getCacheManager(
                 null, applicationContext.getClassLoader(), new Properties());
+        <%_ } else if (cacheProvider === 'hazelcast') { _%>
+        CacheManager cacheManager = new com.hazelcast.cache.impl.HazelcastServerCachingProvider()
+            .getCacheManager(null, applicationContext.getClassLoader(), new Properties());
         <%_ } else if (cacheProvider === 'redis') { _%>
         CacheManager cacheManager = Caching.getCachingProvider(applicationContext.getClassLoader()).getCacheManager();
         <%_ } _%>
@@ -132,6 +157,9 @@ public class CacheConfiguration {
         <%_ } _%>
         <%_ if (cacheProvider === 'caffeine') { _%>
         // jhipster-needle-caffeine-add-entry
+        <%_ } _%>
+        <%_ if (cacheProvider === 'hazelcast') { _%>
+        // jhipster-needle-hazelcast-add-entry
         <%_ } _%>
         <%_ if (cacheProvider === 'redis') { _%>
         // jhipster-needle-redis-add-entry

--- a/generators/micronaut/templates/src/main/resources/application-dev.yml.ejs
+++ b/generators/micronaut/templates/src/main/resources/application-dev.yml.ejs
@@ -145,6 +145,15 @@ jhipster:
         time-to-live-seconds: 3600 # By default objects stay 1 hour in the cache. This sets expireAfterWrite in Caffeine (https://github.com/ben-manes/caffeine/wiki/Eviction#time-based)
         max-entries: 100 # Number of objects in each cache entry
     <%_ } _%>
+  <%_ if (cacheProvider === 'hazelcast') { _%>
+    hazelcast: # Hazelcast configuration
+      time-to-live-seconds: 3600 # By default objects stay 1 hour in the cache
+      backup-count: 1 # Number of copies for each entry
+      management-center:
+        enabled: false
+        update-interval: 3
+        url:
+  <%_ } _%>
   <%_ if (cacheProvider === 'redis') { _%>
     redis: # Redis configuration
         expiration: 3600 # By default objects stay 1 hour (in seconds) in the cache

--- a/generators/micronaut/templates/src/main/resources/application-prod.yml.ejs
+++ b/generators/micronaut/templates/src/main/resources/application-prod.yml.ejs
@@ -167,6 +167,15 @@ jhipster:
         time-to-live-seconds: 3600 # By default objects stay 1 hour in the cache. This sets expireAfterWrite in Caffeine (https://github.com/ben-manes/caffeine/wiki/Eviction#time-based)
         max-entries: 1000 # Number of objects in each cache entry
     <%_ } _%>
+  <%_ if (cacheProvider === 'hazelcast') { _%>
+    hazelcast: # Hazelcast configuration
+      time-to-live-seconds: 3600 # By default objects stay 1 hour in the cache
+      backup-count: 1 # Number of copies for each entry
+      management-center:
+        enabled: false
+        update-interval: 3
+        url:
+  <%_ } _%>
     <%_ if (cacheProvider === 'redis') { _%>
       redis: # Redis configuration
           expiration: 3600 # By default objects stay 1 hour (in seconds) in the cache

--- a/package-lock.json
+++ b/package-lock.json
@@ -1251,6 +1251,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -2128,6 +2129,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.5.tgz",
       "integrity": "sha512-vvmsN0r7rguA+FySiCsbaTTobSftpIDIpPW81trAmsv9TGxg3YCujAxRYp/Uy8xmDgYCzzgulG62H7KYUFmeIg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^5.0.0",
         "@octokit/graphql": "^8.2.2",
@@ -2897,6 +2899,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.15.tgz",
       "integrity": "sha512-R5muMcZob3/Jjchn5LcO8jdKwSCbzqmPB6ruBxMcf9kbxtniZHP327s6C37iOfuw8mbKK3cAQa7sEl7afLrQ8A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2922,6 +2925,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.32.0.tgz",
       "integrity": "sha512-/jU9ettcntkBFmWUzzGgsClEi2ZFiikMX5eEQsmxIAWMOn4H3D4rvHssstmAHGVvrYnaMqdWWWg0b5M6IN/MTQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "8.32.0",
@@ -2951,6 +2955,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.32.0.tgz",
       "integrity": "sha512-B2MdzyWxCE2+SqiZHAjPphft+/2x2FlO9YBx7eKE1BCb+rqBlQdhtAEhzIEdozHd55DXPmxBdpMygFJjfjjA9A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.32.0",
         "@typescript-eslint/types": "8.32.0",
@@ -3455,6 +3460,7 @@
       "resolved": "https://registry.npmjs.org/@yeoman/adapter/-/adapter-2.1.1.tgz",
       "integrity": "sha512-GJqZ/e+IkgAIaUUqBNngR2Y53eVCiJeMrqx8cLATDauEB6/SdEUIGeyRjaWuXdg+kAJHreFtNdBUDmfHO1lc0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/core": "^10.0.0",
         "chalk": "^5.2.0",
@@ -3578,6 +3584,7 @@
       "resolved": "https://registry.npmjs.org/@yeoman/types/-/types-1.6.0.tgz",
       "integrity": "sha512-7Deh9qpDCoOmQal7Sdicb1v/Qv0KFhLqDHnSKh9NBKvvU4EKAFXmd4MuXFvGTCLQfKhuZ6doiM9CMUd4jGp25w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^16.13.0 || >=18.12.0"
       },
@@ -3626,6 +3633,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4211,6 +4219,7 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
       "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.0.3",
         "@chevrotain/gast": "11.0.3",
@@ -4925,6 +4934,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.26.0.tgz",
       "integrity": "sha512-Hx0MOjPh6uK9oq9nVsATZKE/Wlbai7KFjfCuw9UHaguDW3x+HF0O5nIi3ud39TWgrTjTO5nHxmL3R1eANinWHQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4988,6 +4998,7 @@
       "integrity": "sha512-Epgp/EofAUeEpIdZkW60MHKvPyru1ruQJxPL+WIycnaPApuseK0Zpkrh/FwL9oIpQvIhJwV7ptOy0DWUjTlCiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -5309,6 +5320,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6127,6 +6139,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
       "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -6892,6 +6905,7 @@
       "resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-4.1.2.tgz",
       "integrity": "sha512-CMwusHK+Kz0tu1qjgbd0rwcJxzgg76jlkPpqK+pDTv8Hth8JyM7JlgxNWaAFRKe969HATPTz/sp8T63QflyI+w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": ">=18",
         "@types/vinyl": "^2.0.8",
@@ -8242,6 +8256,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9660,6 +9675,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9802,6 +9818,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10025,6 +10042,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -10138,6 +10156,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11156,6 +11175,7 @@
       "integrity": "sha512-eO0Vq66N57wFyLwbGZDFykuSTiYTP9lOwLqVEFwXnpoZ/qI+OXidrsO5VF2OUzm6bDXqOh+gHxPgptmUQWdaQQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash-es": "^4.17.21",
         "mem-fs-editor": "^11.1.1",


### PR DESCRIPTION
## Summary

Wire up Hazelcast as a fully supported cache provider in the Micronaut blueprint:

- Add Hazelcast branch to CacheConfiguration.java.ejs (imports, constructor config, cacheManager, needle)
- Enable Hazelcast in micronaut-cache/generator.js for ddNeedles and customizeFiles
- Add Hazelcast YAML config blocks to pplication-dev.yml.ejs and pplication-prod.yml.ejs
- Add regression tests verifying Hazelcast cache generation

Closes #47

## Testing

```
npx vitest run generators/micronaut-cache/generator.spec.js
```

## Notes

- The command.js and dependencies.mjs already listed Hazelcast as a supported option with Maven dependencies; this PR wires up the remaining template and generator logic.
- Hazelcast Spring dependency (hazelcast-spring) is used for JCache compatibility, matching the existing dependency definition.