### PR TITLE
feat: add MongoDB support

### DIFF
--- a/generators/entity/templates/src/main/java/package/domain/Entity.java.ejs
+++ b/generators/entity/templates/src/main/java/package/domain/Entity.java.ejs
@@ -1,0 +1,46 @@
+package <%= packageFolder %>.domain;
+
+<%_ if (databaseType === 'mongodb') { _%>
+import io.micronaut.data.annotation.MappedEntity;
+import io.micronaut.data.mongodb.annotation.MongoRepository;
+import org.bson.codecs.pojo.annotations.BsonId;
+import org.bson.types.ObjectId;
+<%_ } else { _%>
+import io.micronaut.data.annotation.MappedEntity;
+import io.micronaut.data.annotation.Id;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+<%_ } _%>
+
+@MappedEntity
+public class <%= entityClass %> {
+<%_ if (databaseType === 'mongodb') { _%>
+    @BsonId
+    private ObjectId id;
+<%_ } else { _%>
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+<%_ } _%>
+
+    public <%= entityClass %>() {
+    }
+
+<%_ if (databaseType === 'mongodb') { _%>
+    public ObjectId getId() {
+        return id;
+    }
+
+    public void setId(ObjectId id) {
+        this.id = id;
+    }
+<%_ } else { _%>
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+<%_ } _%>
+}

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -1,0 +1,59 @@
+plugins {
+    id 'java'
+    id 'io.micronaut.application' version '<%= micronautVersion %>'
+    id 'io.micronaut.library' version '<%= micronautVersion %>'
+}
+
+version = '0.0.1'
+
+group = '<%= packageFolder %>'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    annotationProcessor 'io.micronaut:micronaut-http-validation'
+    annotationProcessor 'io.micronaut.serde:micronaut-serde-processor'
+    
+    <%_ if (databaseType === 'mongodb') { _%>
+    annotationProcessor 'io.micronaut.data:micronaut-data-processor'
+    annotationProcessor 'io.micronaut.mongodb:micronaut-mongo-annotation-processor'
+    implementation 'io.micronaut.data:micronaut-data-mongodb'
+    implementation 'io.micronaut.mongodb:micronaut-mongo-sync'
+    <%_ } else { _%>
+    annotationProcessor 'io.micronaut.data:micronaut-data-processor'
+    implementation 'io.micronaut.data:micronaut-data-jdbc'
+    implementation 'io.micronaut.sql:micronaut-jdbc-hikari'
+    <%_ if (databaseType === 'mysql') { _%>
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    <%_ } else if (databaseType === 'postgresql') { _%>
+    runtimeOnly 'org.postgresql:postgresql'
+    <%_ } _%>
+    <%_ } _%>
+    
+    implementation 'io.micronaut:micronaut-http-client'
+    implementation 'io.micronaut.serde:micronaut-serde-jackson'
+    implementation 'io.micronaut.validation:micronaut-validation'
+    
+    runtimeOnly 'ch.qos.logback:logback-classic'
+    
+    testAnnotationProcessor 'io.micronaut:micronaut-inject-java'
+    testImplementation 'io.micronaut.test:micronaut-test-junit5'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+}
+
+application {
+    mainClass = '<%= packageFolder %>.Application'
+}
+
+java {
+    sourceCompatibility = JavaVersion.toVersion('<%= javaVersion %>')
+    targetCompatibility = JavaVersion.toVersion('<%= javaVersion %>')
+}
+
+tasks.withType(JavaCompile) {
+    options.fork = true
+    options.compilerArgs += '-parameters'
+}

--- a/generators/server/templates/docker-compose.yml.ejs
+++ b/generators/server/templates/docker-compose.yml.ejs
@@ -1,0 +1,70 @@
+version: '3.8'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      - MICRONAUT_ENVIRONMENTS=docker
+<%_ if (databaseType === 'mongodb') { _%>
+      - MONGOURI=mongodb://mongodb:27017/<%= baseName %>
+    depends_on:
+      - mongodb
+<%_ } else { _%>
+      - DATASOURCES_DEFAULT_URL=jdbc:<%= databaseType %>://<%= databaseType %>:3306/<%= baseName %>
+    depends_on:
+      - <%= databaseType %>
+<%_ } _%>
+    networks:
+      - app-network
+
+<%_ if (databaseType === 'mongodb') { _%>
+  mongodb:
+    image: mongo:6.0
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongodb_data:/data/db
+    networks:
+      - app-network
+<%_ } else if (databaseType === 'mysql') { _%>
+  mysql:
+    image: mysql:8.0
+    ports:
+      - "3306:3306"
+    environment:
+      - MYSQL_ROOT_PASSWORD=password
+      - MYSQL_DATABASE=<%= baseName %>
+    volumes:
+      - mysql_data:/var/lib/mysql
+    networks:
+      - app-network
+<%_ } else if (databaseType === 'postgresql') { _%>
+  postgresql:
+    image: postgres:15
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=<%= baseName %>
+    volumes:
+      - postgresql_data:/var/lib/postgresql/data
+    networks:
+      - app-network
+<%_ } _%>
+
+volumes:
+<%_ if (databaseType === 'mongodb') { _%>
+  mongodb_data:
+<%_ } else if (databaseType === 'mysql') { _%>
+  mysql_data:
+<%_ } else if (databaseType === 'postgresql') { _%>
+  postgresql_data:
+<%_ } _%>
+
+networks:
+  app-network:
+    driver: bridge

--- a/generators/server/templates/src/main/resources/application.yml.ejs
+++ b/generators/server/templates/src/main/resources/application.yml.ejs
@@ -1,0 +1,32 @@
+micronaut:
+  application:
+    name: <%= baseName %>
+  server:
+    port: 8080
+
+<%_ if (databaseType === 'mongodb') { _%>
+mongouri: mongodb://localhost:27017/<%= baseName %>
+
+data:
+  mongodb:
+    uri: ${mongouri}
+<%_ } else { _%>
+datasources:
+  default:
+    url: jdbc:<%= databaseType %>://localhost:3306/<%= baseName %>
+    driverClassName: <%_ if (databaseType === 'mysql') { _%>com.mysql.cj.jdbc.Driver<%_ } else if (databaseType === 'postgresql') { _%>org.postgresql.Driver<%_ } _%>
+    username: root
+    password: password
+<%_ } _%>
+
+jpa:
+  default:
+    entity-scan:
+      packages: '<%= packageFolder %>.domain'
+    repositories:
+      enabled: true
+
+logging:
+  level:
+    root: INFO
+    <%= packageFolder %>: DEBUG


### PR DESCRIPTION
## Summary

This PR implements MongoDB database support as requested in issue #49. The implementation reuses an existing commit to ensure consistency.

Closes #49

## Testing

Verify the MongoDB integration using the following commands:

```bash
npm run test:integration
```

```bash
docker-compose up -d mongo
```

## Notes

- Patches applied by reusing existing commit.
- Ensure the `MONGODB_URI` environment variable is set correctly.